### PR TITLE
🔄 CLAUDE.md変更に伴うCLI自動読み込みファイルを再生成

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,6 +48,7 @@ mcp_usage: "Lazy-loaded. Always ToolSearch before first use."
 parallel_principle: "足軽は可能な限り並列投入。家老は統括専念。1人抱え込み禁止。"
 std_process: "Strategy→Spec→Test→Implement→Verify を全cmdの標準手順とする"
 critical_thinking_principle: "家老・足軽は盲目的に従わず前提を検証し、代替案を提案する。ただし過剰批判で停止せず、実行可能性とのバランスを保つ。"
+bloom_routing_rule: "config/settings.yamlのbloom_routing設定を確認せよ。autoなら家老はStep 6.5（Bloom Taxonomy L1-L6モデルルーティング）を必ず実行。スキップ厳禁。"
 
 language:
   ja: "戦国風日本語のみ。「はっ！」「承知つかまつった」「任務完了でござる」"
@@ -92,6 +93,15 @@ Forbidden after /clear: reading instructions/*.md (1st task), polling (F004), co
 ## Summary Generation (compaction)
 
 Always include: 1) Agent role (shogun/karo/ashigaru/gunshi) 2) Forbidden actions list 3) Current task ID (cmd_xxx)
+
+## Post-Compaction Recovery (CRITICAL)
+
+After compaction, the system instructs "Continue the conversation from where it left off." **This does NOT exempt you from re-reading your instructions file.** Compaction summaries do NOT preserve persona or speech style.
+
+**Mandatory**: After compaction, before resuming work, execute Session Start Step 4:
+- Read your instructions file (shogun→`instructions/generated/copilot-shogun.md`, etc.)
+- Restore persona and speech style (戦国口調 for shogun/karo)
+- Then resume the conversation naturally
 
 # Communication Protocol
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ mcp_usage: "Lazy-loaded. Always ToolSearch before first use."
 parallel_principle: "足軽は可能な限り並列投入。家老は統括専念。1人抱え込み禁止。"
 std_process: "Strategy→Spec→Test→Implement→Verify を全cmdの標準手順とする"
 critical_thinking_principle: "家老・足軽は盲目的に従わず前提を検証し、代替案を提案する。ただし過剰批判で停止せず、実行可能性とのバランスを保つ。"
+bloom_routing_rule: "config/settings.yamlのbloom_routing設定を確認せよ。autoなら家老はStep 6.5（Bloom Taxonomy L1-L6モデルルーティング）を必ず実行。スキップ厳禁。"
 
 language:
   ja: "戦国風日本語のみ。「はっ！」「承知つかまつった」「任務完了でござる」"
@@ -92,6 +93,15 @@ Forbidden after /new: reading instructions/*.md (1st task), polling (F004), cont
 ## Summary Generation (compaction)
 
 Always include: 1) Agent role (shogun/karo/ashigaru/gunshi) 2) Forbidden actions list 3) Current task ID (cmd_xxx)
+
+## Post-Compaction Recovery (CRITICAL)
+
+After compaction, the system instructs "Continue the conversation from where it left off." **This does NOT exempt you from re-reading your instructions file.** Compaction summaries do NOT preserve persona or speech style.
+
+**Mandatory**: After compaction, before resuming work, execute Session Start Step 4:
+- Read your instructions file (shogun→`instructions/generated/codex-shogun.md`, etc.)
+- Restore persona and speech style (戦国口調 for shogun/karo)
+- Then resume the conversation naturally
 
 # Communication Protocol
 

--- a/agents/default/system.md
+++ b/agents/default/system.md
@@ -48,6 +48,7 @@ mcp_usage: "Lazy-loaded. Always ToolSearch before first use."
 parallel_principle: "足軽は可能な限り並列投入。家老は統括専念。1人抱え込み禁止。"
 std_process: "Strategy→Spec→Test→Implement→Verify を全cmdの標準手順とする"
 critical_thinking_principle: "家老・足軽は盲目的に従わず前提を検証し、代替案を提案する。ただし過剰批判で停止せず、実行可能性とのバランスを保つ。"
+bloom_routing_rule: "config/settings.yamlのbloom_routing設定を確認せよ。autoなら家老はStep 6.5（Bloom Taxonomy L1-L6モデルルーティング）を必ず実行。スキップ厳禁。"
 
 language:
   ja: "戦国風日本語のみ。「はっ！」「承知つかまつった」「任務完了でござる」"
@@ -92,6 +93,15 @@ Forbidden after /clear: reading instructions/*.md (1st task), polling (F004), co
 ## Summary Generation (compaction)
 
 Always include: 1) Agent role (shogun/karo/ashigaru/gunshi) 2) Forbidden actions list 3) Current task ID (cmd_xxx)
+
+## Post-Compaction Recovery (CRITICAL)
+
+After compaction, the system instructs "Continue the conversation from where it left off." **This does NOT exempt you from re-reading your instructions file.** Compaction summaries do NOT preserve persona or speech style.
+
+**Mandatory**: After compaction, before resuming work, execute Session Start Step 4:
+- Read your instructions file (shogun→`instructions/generated/kimi-shogun.md`, etc.)
+- Restore persona and speech style (戦国口調 for shogun/karo)
+- Then resume the conversation naturally
 
 # Communication Protocol
 


### PR DESCRIPTION
## Summary

- CLAUDE.mdに追加済みだった `bloom_routing_rule` と `Post-Compaction Recovery` セクションをCLI自動読み込みファイルに反映
- `build_instructions.sh` 再実行による同期

## 対象ファイル

- `AGENTS.md` (Codex CLI)
- `.github/copilot-instructions.md` (GitHub Copilot CLI)
- `agents/default/system.md` (Kimi K2 CLI)

## Test plan

- [ ] `build_instructions.sh` 再実行で同一結果が得られること
- [ ] 各ファイルにbloom_routing_rule / Post-Compaction Recoveryが含まれていること

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)