### PR TITLE
🔔 家老ntfy未送信対策: step11.7をCRITICAL強調+compactionサマリーに追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Forbidden after /clear: reading instructions/*.md (1st task), polling (F004), co
 
 ## Summary Generation (compaction)
 
-Always include: 1) Agent role (shogun/karo/ashigaru/gunshi) 2) Forbidden actions list 3) Current task ID (cmd_xxx)
+Always include: 1) Agent role (shogun/karo/ashigaru/gunshi) 2) Forbidden actions list 3) Current task ID (cmd_xxx) 4) (karo only) ntfy送信済みか否か（未送信なら復帰後すぐ実行）
 
 ## Post-Compaction Recovery (CRITICAL)
 

--- a/instructions/karo.md
+++ b/instructions/karo.md
@@ -139,7 +139,11 @@ workflow:
     note: "Scan all task YAMLs for blocked_by containing completed task_id. Remove and unblock."
   - step: 11.7
     action: saytask_notify
-    note: "Update streaks.yaml and send ntfy notification. See SayTask section."
+    note: |
+      **【CRITICAL: MANDATORY — NEVER SKIP】**
+      1. Update saytask/streaks.yaml (see SayTask section for logic)
+      2. bash scripts/ntfy.sh "✅ cmd_{id} 完了 — {summary}"
+      このステップを省略すると殿への完了通知が届かない。スキップ厳禁。
   - step: 12
     action: check_pending_after_report
     note: |


### PR DESCRIPTION
## 概要

Closes #13

家老がレポート処理時に ntfy.sh を呼ばない問題を修正する。

## 根本原因（Issue #13 より）

- コードや設定の問題ではなく、家老自身の行動フローの問題
- step 11.7 の note が「See SayTask section.」と参照先案内のみで、重要度が伝わりにくかった
- コンテキスト圧縮後にntfy送信済みかどうかが復帰時に不明だった

## 変更内容

### `instructions/karo.md`
- step 11.7 の note を `**【CRITICAL: MANDATORY — NEVER SKIP】**` で強調
- 実行すべきコマンド（`bash scripts/ntfy.sh "✅ cmd_{id} 完了 — {summary}"`）を step 内に直接記載
- スキップ時の影響を明示

### `CLAUDE.md`
- `## Summary Generation (compaction)` に `(karo only) ntfy送信済みか否か（未送信なら復帰後すぐ実行）` を追記
- compaction後のリカバリ時に未送信ntfyを即時実行できるよう状態保持

## 関連

- Issue #14（echo_shout改善）の同様アプローチを参考にした

🤖 Generated with [Claude Code](https://claude.com/claude-code)