### PR TITLE
📋 cmd_newタスク追跡漏れ改善: inbox処理順序強制+ダッシュボード可視化

### DIFF
--- a/instructions/karo.md
+++ b/instructions/karo.md
@@ -256,6 +256,22 @@ date "+%Y-%m-%dT%H:%M:%S"    # For YAML (ISO 8601)
 
 ## Inbox Communication Rules
 
+### cmd_new処理（MANDATORY: 順序厳守）
+
+cmd_newタイプのメッセージを受信した場合、以下の**順序を必ず守ること**:
+
+1. **先に** `queue/shogun_to_karo.yaml` の `commands:` リストにエントリ追加
+   ```yaml
+   - id: cmd_NNN
+     status: pending
+     received_at: '<inbox messageのtimestamp>'
+     purpose: '<messageの内容を1行で要約>'
+   ```
+2. **その後** inbox メッセージを `read: true` に更新
+
+**この順序を逆にしてはならない。**
+read: trueを先にすると、コンパクションや/clearが入った場合にcmd_newが追跡不能になる。
+
 ### Sending Messages to Ashigaru
 
 ```bash
@@ -583,6 +599,12 @@ Karo and Gunshi update dashboard.md. Gunshi updates during quality check aggrega
 | Report received | 戦果 | Move completed task (newest first, descending) |
 | Notification sent | ntfy + streaks | Send completion notification |
 | Action needed | 🚨 要対応 | Items requiring lord's judgment |
+
+### 📋 受信済み未着手タスク セクション
+
+- `queue/shogun_to_karo.yaml` の `status: pending` のcmdを一覧表示
+- cmd_newを受信して`shogun_to_karo.yaml`にpendingエントリを追加したら、このセクションにも追記
+- タスク着手（in_progress）になったら🔄進行中へ移動し、このセクションから削除
 
 ### 戦果テーブル: 成果物列ルール
 


### PR DESCRIPTION
## 概要

将軍からのcmd_newが追跡されずに消える問題を、処理フローの順序強制と可視化で対処。

Closes #17

## 変更内容

### `instructions/karo.md`
- `cmd_new処理（MANDATORY: 順序厳守）` セクション追加
  - ① `shogun_to_karo.yaml` にエントリ追加（status: pending）**→先に**
  - ② inbox を `read: true` に更新 **→後で**
  - この順序を逆にすると、コンパクション時にcmd_newが消失する旨を明示
- ダッシュボード「📋 受信済み未着手タスク」セクションの管理ルール追記

### `dashboard.md`
- `## 📋 受信済み未着手タスク` セクション追加（🚨要対応の直後に配置）
- 将軍が「指示が消えた」を即座に確認可能な一覧表示

## 根本原因

`read: true` は「読んだ」を意味するが「タスク化した」を保証しない。
複数 `cmd_new` が同時に届いた場合、一部の記録が漏れることがあった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)