### PR TITLE
📝 スキル化判断基準をCLAUDE.mdに追加 (close #37)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -220,6 +220,8 @@ System manages ALL white-collar work, not just self-improvement. Project folders
 4. **Karo state**: Before sending commands, verify karo isn't busy: `tmux capture-pane -t multiagent:0.0 -p | tail -20`
 5. **Screenshots**: See `config/settings.yaml` → `screenshot.path`
 6. **Skill candidates**: Ashigaru reports include `skill_candidate:`. Karo collects → dashboard. Shogun approves → creates design doc.
+   - **スキル化する条件（いずれかに該当）**: (a) 対話的指示の省略 — エージェントへの複数ステップの指示を定型化し1コマンドで実行したい (b) 決定論的な振る舞いの保証 — スクリプト化（bash/Python等）でLLMの判断ブレを排除したい (c) クロスプロジェクト再利用 — 特定プロジェクトに閉じず複数プロジェクトで繰り返し使う
+   - **スキル化しない**: コード内で関数として実装済み / 1〜数行のパターン / 外部APIの手順知見 → 関数化またはコンテキストファイル(`context/*.md`)に記載で十分
 7. **Action Required Rule (CRITICAL)**: ALL items needing Lord's decision → dashboard.md 🚨要対応 section. ALWAYS. Even if also written elsewhere. Forgetting = Lord gets angry.
 
 # Test Rules (all agents)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,8 @@ System manages ALL white-collar work, not just self-improvement. Project folders
 4. **Karo state**: Before sending commands, verify karo isn't busy: `tmux capture-pane -t multiagent:0.0 -p | tail -20`
 5. **Screenshots**: See `config/settings.yaml` → `screenshot.path`
 6. **Skill candidates**: Ashigaru reports include `skill_candidate:`. Karo collects → dashboard. Shogun approves → creates design doc.
+   - **スキル化する条件（いずれかに該当）**: (a) 対話的指示の省略 — エージェントへの複数ステップの指示を定型化し1コマンドで実行したい (b) 決定論的な振る舞いの保証 — スクリプト化（bash/Python等）でLLMの判断ブレを排除したい (c) クロスプロジェクト再利用 — 特定プロジェクトに閉じず複数プロジェクトで繰り返し使う
+   - **スキル化しない**: コード内で関数として実装済み / 1〜数行のパターン / 外部APIの手順知見 → 関数化またはコンテキストファイル(`context/*.md`)に記載で十分
 7. **Action Required Rule (CRITICAL)**: ALL items needing Lord's decision → dashboard.md 🚨要対応 section. ALWAYS. Even if also written elsewhere. Forgetting = Lord gets angry.
 
 # Test Rules (all agents)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,6 +220,8 @@ System manages ALL white-collar work, not just self-improvement. Project folders
 4. **Karo state**: Before sending commands, verify karo isn't busy: `tmux capture-pane -t multiagent:0.0 -p | tail -20`
 5. **Screenshots**: See `config/settings.yaml` → `screenshot.path`
 6. **Skill candidates**: Ashigaru reports include `skill_candidate:`. Karo collects → dashboard. Shogun approves → creates design doc.
+   - **スキル化する条件（いずれかに該当）**: (a) 対話的指示の省略 — エージェントへの複数ステップの指示を定型化し1コマンドで実行したい (b) 決定論的な振る舞いの保証 — スクリプト化（bash/Python等）でLLMの判断ブレを排除したい (c) クロスプロジェクト再利用 — 特定プロジェクトに閉じず複数プロジェクトで繰り返し使う
+   - **スキル化しない**: コード内で関数として実装済み / 1〜数行のパターン / 外部APIの手順知見 → 関数化またはコンテキストファイル(`context/*.md`)に記載で十分
 7. **Action Required Rule (CRITICAL)**: ALL items needing Lord's decision → dashboard.md 🚨要対応 section. ALWAYS. Even if also written elsewhere. Forgetting = Lord gets angry.
 
 # Test Rules (all agents)

--- a/agents/default/system.md
+++ b/agents/default/system.md
@@ -220,6 +220,8 @@ System manages ALL white-collar work, not just self-improvement. Project folders
 4. **Karo state**: Before sending commands, verify karo isn't busy: `tmux capture-pane -t multiagent:0.0 -p | tail -20`
 5. **Screenshots**: See `config/settings.yaml` → `screenshot.path`
 6. **Skill candidates**: Ashigaru reports include `skill_candidate:`. Karo collects → dashboard. Shogun approves → creates design doc.
+   - **スキル化する条件（いずれかに該当）**: (a) 対話的指示の省略 — エージェントへの複数ステップの指示を定型化し1コマンドで実行したい (b) 決定論的な振る舞いの保証 — スクリプト化（bash/Python等）でLLMの判断ブレを排除したい (c) クロスプロジェクト再利用 — 特定プロジェクトに閉じず複数プロジェクトで繰り返し使う
+   - **スキル化しない**: コード内で関数として実装済み / 1〜数行のパターン / 外部APIの手順知見 → 関数化またはコンテキストファイル(`context/*.md`)に記載で十分
 7. **Action Required Rule (CRITICAL)**: ALL items needing Lord's decision → dashboard.md 🚨要対応 section. ALWAYS. Even if also written elsewhere. Forgetting = Lord gets angry.
 
 # Test Rules (all agents)


### PR DESCRIPTION
## Summary
- Shogun Mandatory Rules #6 にスキル化する/しないの判断基準を明文化
- スキル化する条件: (a) 対話的指示の省略 (b) 決定論的な振る舞いの保証 (c) クロスプロジェクト再利用
- スキル化しない例: 関数として実装済み / 数行のパターン / 外部API手順知見

## Test plan
- [ ] CLAUDE.md の Shogun Mandatory Rules #6 に判断基準が追記されていること
- [ ] 生成ファイル（AGENTS.md, .github/copilot-instructions.md, agents/default/system.md）にも同内容が反映されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)