### PR TITLE
🔀 upstream v4.4.0 を取り込む（daily log + --effort max）

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,6 +22,7 @@ files:
   reports: "queue/reports/{task_id}_report.yaml"  # Ashigaru completion reports (task-unit files)
   gunshi_qc: "queue/reports/{task_id}_qc.yaml"    # Gunshi QC results (task-unit files)
   dashboard: dashboard.md              # Human-readable summary (secondary data)
+  daily_log: "logs/daily/YYYY-MM-DD.md" # Karo appends cmd summary on completion. Shogun reads for daily reports.
   ntfy_inbox: queue/ntfy_inbox.yaml    # Incoming ntfy messages from Lord's phone
 
 cmd_format:

--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ tests/specs/osato_lms_*
 # Android companion app
 !android/
 !android/**
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ files:
   reports: "queue/reports/{task_id}_report.yaml"  # Ashigaru completion reports (task-unit files)
   gunshi_qc: "queue/reports/{task_id}_qc.yaml"    # Gunshi QC results (task-unit files)
   dashboard: dashboard.md              # Human-readable summary (secondary data)
+  daily_log: "logs/daily/YYYY-MM-DD.md" # Karo appends cmd summary on completion. Shogun reads for daily reports.
   ntfy_inbox: queue/ntfy_inbox.yaml    # Incoming ntfy messages from Lord's phone
 
 cmd_format:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.4.0] - 2026-03-28
+
+### Added
+- karo daily log: cmd完了時に `logs/daily/YYYY-MM-DD.md` へサマリーを自動追記する機能を導入 (PR #95)
+- `.gitignore`: `.claude/settings.local.json` を除外対象に追加
+
+### Changed
+- `instructions/karo.md`: ntfy通知ステップを6→7に移動、daily log appendをステップ6に挿入
+- `instructions/roles/karo_role.md`: 同期済み
+- 全CLI向け generated instructions を再生成（codex/copilot/kimi-karo.md）
+
+## [4.3.0] - 2026-03-28
+
+### Added
+- `shutsujin_departure.sh`: all Claude Code agents now launch with `--effort max` by default (shogun, karo, ashigaru, gunshi)
+
 ## [4.2.0] - 2026-03-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ files:
   reports: "queue/reports/{task_id}_report.yaml"  # Ashigaru completion reports (task-unit files)
   gunshi_qc: "queue/reports/{task_id}_qc.yaml"    # Gunshi QC results (task-unit files)
   dashboard: dashboard.md              # Human-readable summary (secondary data)
+  daily_log: "logs/daily/YYYY-MM-DD.md" # Karo appends cmd summary on completion. Shogun reads for daily reports.
   ntfy_inbox: queue/ntfy_inbox.yaml    # Incoming ntfy messages from Lord's phone
 
 cmd_format:

--- a/agents/default/system.md
+++ b/agents/default/system.md
@@ -22,6 +22,7 @@ files:
   reports: "queue/reports/{task_id}_report.yaml"  # Ashigaru completion reports (task-unit files)
   gunshi_qc: "queue/reports/{task_id}_qc.yaml"    # Gunshi QC results (task-unit files)
   dashboard: dashboard.md              # Human-readable summary (secondary data)
+  daily_log: "logs/daily/YYYY-MM-DD.md" # Karo appends cmd summary on completion. Shogun reads for daily reports.
   ntfy_inbox: queue/ntfy_inbox.yaml    # Incoming ntfy messages from Lord's phone
 
 cmd_format:

--- a/instructions/generated/codex-karo.md
+++ b/instructions/generated/codex-karo.md
@@ -235,7 +235,13 @@ Push notifications to the lord's phone via ntfy. Karo manages streaks and notifi
    - Streak logic: last_date=today → keep current; last_date=yesterday → current+1; else → reset to 1
    - Update `streak.longest` if current > longest
    - Check frog: if any completed task_id matches `today.frog` → 🐸 notification, reset frog
-6. Send ntfy notification
+6. **Daily log append** → `logs/daily/YYYY-MM-DD.md` に cmd サマリーを追記:
+   - cmd ID, ステータス, 目的
+   - 足軽ごとの成果物一覧（subtask_id, 担当, 作成/変更ファイル）
+   - タイムライン（開始〜完了）
+   - 課題・気づき（あれば）
+   - ファイルが無ければヘッダー `# 日報 YYYY-MM-DD` 付きで新規作成
+7. Send ntfy notification
 
 ## OSS Pull Request Review
 

--- a/instructions/generated/copilot-karo.md
+++ b/instructions/generated/copilot-karo.md
@@ -235,7 +235,13 @@ Push notifications to the lord's phone via ntfy. Karo manages streaks and notifi
    - Streak logic: last_date=today → keep current; last_date=yesterday → current+1; else → reset to 1
    - Update `streak.longest` if current > longest
    - Check frog: if any completed task_id matches `today.frog` → 🐸 notification, reset frog
-6. Send ntfy notification
+6. **Daily log append** → `logs/daily/YYYY-MM-DD.md` に cmd サマリーを追記:
+   - cmd ID, ステータス, 目的
+   - 足軽ごとの成果物一覧（subtask_id, 担当, 作成/変更ファイル）
+   - タイムライン（開始〜完了）
+   - 課題・気づき（あれば）
+   - ファイルが無ければヘッダー `# 日報 YYYY-MM-DD` 付きで新規作成
+7. Send ntfy notification
 
 ## OSS Pull Request Review
 

--- a/instructions/generated/karo.md
+++ b/instructions/generated/karo.md
@@ -235,7 +235,13 @@ Push notifications to the lord's phone via ntfy. Karo manages streaks and notifi
    - Streak logic: last_date=today → keep current; last_date=yesterday → current+1; else → reset to 1
    - Update `streak.longest` if current > longest
    - Check frog: if any completed task_id matches `today.frog` → 🐸 notification, reset frog
-6. Send ntfy notification
+6. **Daily log append** → `logs/daily/YYYY-MM-DD.md` に cmd サマリーを追記:
+   - cmd ID, ステータス, 目的
+   - 足軽ごとの成果物一覧（subtask_id, 担当, 作成/変更ファイル）
+   - タイムライン（開始〜完了）
+   - 課題・気づき（あれば）
+   - ファイルが無ければヘッダー `# 日報 YYYY-MM-DD` 付きで新規作成
+7. Send ntfy notification
 
 ## OSS Pull Request Review
 

--- a/instructions/generated/kimi-karo.md
+++ b/instructions/generated/kimi-karo.md
@@ -235,7 +235,13 @@ Push notifications to the lord's phone via ntfy. Karo manages streaks and notifi
    - Streak logic: last_date=today → keep current; last_date=yesterday → current+1; else → reset to 1
    - Update `streak.longest` if current > longest
    - Check frog: if any completed task_id matches `today.frog` → 🐸 notification, reset frog
-6. Send ntfy notification
+6. **Daily log append** → `logs/daily/YYYY-MM-DD.md` に cmd サマリーを追記:
+   - cmd ID, ステータス, 目的
+   - 足軽ごとの成果物一覧（subtask_id, 担当, 作成/変更ファイル）
+   - タイムライン（開始〜完了）
+   - 課題・気づき（あれば）
+   - ファイルが無ければヘッダー `# 日報 YYYY-MM-DD` 付きで新規作成
+7. Send ntfy notification
 
 ## OSS Pull Request Review
 

--- a/instructions/karo.md
+++ b/instructions/karo.md
@@ -526,7 +526,13 @@ Push notifications to the lord's phone via ntfy. Karo manages streaks and notifi
    - Streak logic: last_date=today → keep current; last_date=yesterday → current+1; else → reset to 1
    - Update `streak.longest` if current > longest
    - Check frog: if any completed task_id matches `today.frog` → 🐸 notification, reset frog
-7. → Step 13 (ntfy_gate) へ進む
+7. **Daily log append** → `logs/daily/YYYY-MM-DD.md` に cmd サマリーを追記:
+   - cmd ID, ステータス, 目的
+   - 足軽ごとの成果物一覧（subtask_id, 担当, 作成/変更ファイル）
+   - タイムライン（開始〜完了）
+   - 課題・気づき（あれば）
+   - ファイルが無ければヘッダー `# 日報 YYYY-MM-DD` 付きで新規作成
+8. → Step 13 (ntfy_gate) へ進む
 
 ### Karo Direct Work Completion (PR merge, direct tasks)
 
@@ -534,7 +540,8 @@ When Karo directly completes a cmd (PR merge, direct implementation, analysis):
 1. Complete the work
 2. **Immediately update `queue/shogun_to_karo.yaml`**: Set `status: done` and `completed_at`.
 3. Update dashboard.md
-4. → Step 13 (ntfy_gate) へ進む
+4. **Daily log append** → `logs/daily/YYYY-MM-DD.md` に cmd サマリーを追記
+5. → Step 13 (ntfy_gate) へ進む
 
 ### Eat the Frog (today.frog)
 

--- a/instructions/roles/karo_role.md
+++ b/instructions/roles/karo_role.md
@@ -234,7 +234,13 @@ Push notifications to the lord's phone via ntfy. Karo manages streaks and notifi
    - Streak logic: last_date=today → keep current; last_date=yesterday → current+1; else → reset to 1
    - Update `streak.longest` if current > longest
    - Check frog: if any completed task_id matches `today.frog` → 🐸 notification, reset frog
-6. Send ntfy notification
+6. **Daily log append** → `logs/daily/YYYY-MM-DD.md` に cmd サマリーを追記:
+   - cmd ID, ステータス, 目的
+   - 足軽ごとの成果物一覧（subtask_id, 担当, 作成/変更ファイル）
+   - タイムライン（開始〜完了）
+   - 課題・気づき（あれば）
+   - ファイルが無ければヘッダー `# 日報 YYYY-MM-DD` 付きで新規作成
+7. Send ntfy notification
 
 ## OSS Pull Request Review
 

--- a/shutsujin_departure.sh
+++ b/shutsujin_departure.sh
@@ -660,7 +660,7 @@ if [ "$SETUP_ONLY" = false ]; then
 
     # 将軍: CLI Adapter経由でコマンド構築
     _shogun_cli_type="claude"
-    _shogun_cmd="claude --model opus --dangerously-skip-permissions"
+    _shogun_cmd="claude --model opus --effort max --dangerously-skip-permissions"
     if [ "$CLI_ADAPTER_LOADED" = true ]; then
         _shogun_cli_type=$(get_cli_type "shogun")
         _shogun_cmd=$(build_cli_command "shogun")
@@ -690,7 +690,7 @@ with open(f,'w') as fh: yaml.safe_dump(d, fh, default_flow_style=False, allow_un
     # 家老（pane 0）: CLI Adapter経由でコマンド構築（デフォルト: Sonnet）
     p=$((PANE_BASE + 0))
     _karo_cli_type="claude"
-    _karo_cmd="claude --model sonnet --dangerously-skip-permissions"
+    _karo_cmd="claude --model sonnet --effort max --dangerously-skip-permissions"
     if [ "$CLI_ADAPTER_LOADED" = true ]; then
         _karo_cli_type=$(get_cli_type "karo")
         _karo_cmd=$(build_cli_command "karo")
@@ -712,11 +712,11 @@ with open(f,'w') as fh: yaml.safe_dump(d, fh, default_flow_style=False, allow_un
         for i in $(seq 1 "$_ASHIGARU_COUNT"); do
             p=$((PANE_BASE + i))
             _ashi_cli_type="claude"
-            _ashi_cmd="claude --model opus --dangerously-skip-permissions"
+            _ashi_cmd="claude --model opus --effort max --dangerously-skip-permissions"
             if [ "$CLI_ADAPTER_LOADED" = true ]; then
                 _ashi_cli_type=$(get_cli_type "ashigaru${i}")
                 if [ "$_ashi_cli_type" = "claude" ]; then
-                    _ashi_cmd="claude --model opus --dangerously-skip-permissions"
+                    _ashi_cmd="claude --model opus --effort max --dangerously-skip-permissions"
                 else
                     _ashi_cmd=$(build_cli_command "ashigaru${i}")
                 fi
@@ -736,7 +736,7 @@ with open(f,'w') as fh: yaml.safe_dump(d, fh, default_flow_style=False, allow_un
         for i in $(seq 1 "$_ASHIGARU_COUNT"); do
             p=$((PANE_BASE + i))
             _ashi_cli_type="claude"
-            _ashi_cmd="claude --model sonnet --dangerously-skip-permissions"
+            _ashi_cmd="claude --model sonnet --effort max --dangerously-skip-permissions"
             if [ "$CLI_ADAPTER_LOADED" = true ]; then
                 _ashi_cli_type=$(get_cli_type "ashigaru${i}")
                 _ashi_cmd=$(build_cli_command "ashigaru${i}")
@@ -756,7 +756,7 @@ with open(f,'w') as fh: yaml.safe_dump(d, fh, default_flow_style=False, allow_un
     # 軍師（pane _ASHIGARU_COUNT+1）: Opus Thinking — 戦略立案・設計判断専任
     p=$((PANE_BASE + _ASHIGARU_COUNT + 1))
     _gunshi_cli_type="claude"
-    _gunshi_cmd="claude --model opus --dangerously-skip-permissions"
+    _gunshi_cmd="claude --model opus --effort max --dangerously-skip-permissions"
     if [ "$CLI_ADAPTER_LOADED" = true ]; then
         _gunshi_cli_type=$(get_cli_type "gunshi")
         _gunshi_cmd=$(build_cli_command "gunshi")


### PR DESCRIPTION
## Summary

- **v4.3.0**: `shutsujin_departure.sh` の全エージェント起動に `--effort max` 追加
- **v4.4.0**: cmd完了時に `logs/daily/YYYY-MM-DD.md` へサマリー追記（日報自動生成）
- `.gitignore`: `.claude/settings.local.json` 追加

## コンフリクト解決

`instructions/karo.md` のみコンフリクト発生。以下のように統合:
- upstream の daily log append ステップ → Step 7として追加（streaks.yaml更新の後、ntfy_gateの前）
- fork独自の `→ Step 13 (ntfy_gate)` 参照を保持
- fork独自の `Karo Direct Work Completion` セクションを保持（daily log stepも追加）

## Test plan

- [x] `bats tests/unit/` — 345テスト全通過（SKIP=0）
- [x] コンフリクトマーカーなし確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)