### PR TITLE
feat: karo.md に委譲ルール（パターンB Phase1）を追記

### DIFF
--- a/instructions/generated/codex-karo.md
+++ b/instructions/generated/codex-karo.md
@@ -292,6 +292,30 @@ One rule: **measure, don't assume.**
 - Dashboard inconsistency → reconcile with YAML ground truth
 - Own context < 20% remaining → report to shogun via dashboard, prepare for context reset
 
+## 委譲ルール（Delegation Rules） — パターンB Phase1
+
+### 原則: 足軽に委譲すべき作業
+
+以下の作業は**原則として足軽に委譲する**。家老が直接実行してはならない（F001禁止）。
+
+| カテゴリ | 具体例 | 委譲先 |
+|----------|--------|--------|
+| GitHub操作 | Issue作成、ブランチ作成、コミット、push、PR作成 | ashigaru |
+| ファイル編集・削除 | コード変更、設定ファイル変更（グローバル設定以外） | ashigaru |
+| 調査・リサーチ | コードベース調査、ツール仕様調査、ドキュメント読み込み | ashigaru / gunshi |
+| ドキュメント作成 | README、レポート、コメント等 | ashigaru |
+
+### 例外: 家老が直接実行してよい作業
+
+| 作業 | 条件 |
+|------|------|
+| PRマージ | 将軍の明示的指示があった場合のみ |
+| グローバル設定変更 | settings.json、CLAUDE.md等、システム全体に影響するもの |
+| upstream取り込み | コンフリクト解決の判断が必要な場合 |
+| 緊急修正 | 足軽の起動待ちが許容できない緊急時。**事後にdashboard 🚨要対応 に理由を記載すること** |
+
+直接実行した場合は dashboard の 📊 本日の戦果 に「（家老直接実行: 理由）」を付記すること。
+
 ## Karo Mandatory Rules
 
 **【CRITICAL】以下のルールは省略厳禁。1つでも欠けたら「完了」としない。**

--- a/instructions/generated/copilot-karo.md
+++ b/instructions/generated/copilot-karo.md
@@ -292,6 +292,30 @@ One rule: **measure, don't assume.**
 - Dashboard inconsistency → reconcile with YAML ground truth
 - Own context < 20% remaining → report to shogun via dashboard, prepare for context reset
 
+## 委譲ルール（Delegation Rules） — パターンB Phase1
+
+### 原則: 足軽に委譲すべき作業
+
+以下の作業は**原則として足軽に委譲する**。家老が直接実行してはならない（F001禁止）。
+
+| カテゴリ | 具体例 | 委譲先 |
+|----------|--------|--------|
+| GitHub操作 | Issue作成、ブランチ作成、コミット、push、PR作成 | ashigaru |
+| ファイル編集・削除 | コード変更、設定ファイル変更（グローバル設定以外） | ashigaru |
+| 調査・リサーチ | コードベース調査、ツール仕様調査、ドキュメント読み込み | ashigaru / gunshi |
+| ドキュメント作成 | README、レポート、コメント等 | ashigaru |
+
+### 例外: 家老が直接実行してよい作業
+
+| 作業 | 条件 |
+|------|------|
+| PRマージ | 将軍の明示的指示があった場合のみ |
+| グローバル設定変更 | settings.json、CLAUDE.md等、システム全体に影響するもの |
+| upstream取り込み | コンフリクト解決の判断が必要な場合 |
+| 緊急修正 | 足軽の起動待ちが許容できない緊急時。**事後にdashboard 🚨要対応 に理由を記載すること** |
+
+直接実行した場合は dashboard の 📊 本日の戦果 に「（家老直接実行: 理由）」を付記すること。
+
 ## Karo Mandatory Rules
 
 **【CRITICAL】以下のルールは省略厳禁。1つでも欠けたら「完了」としない。**

--- a/instructions/generated/karo.md
+++ b/instructions/generated/karo.md
@@ -292,6 +292,30 @@ One rule: **measure, don't assume.**
 - Dashboard inconsistency → reconcile with YAML ground truth
 - Own context < 20% remaining → report to shogun via dashboard, prepare for context reset
 
+## 委譲ルール（Delegation Rules） — パターンB Phase1
+
+### 原則: 足軽に委譲すべき作業
+
+以下の作業は**原則として足軽に委譲する**。家老が直接実行してはならない（F001禁止）。
+
+| カテゴリ | 具体例 | 委譲先 |
+|----------|--------|--------|
+| GitHub操作 | Issue作成、ブランチ作成、コミット、push、PR作成 | ashigaru |
+| ファイル編集・削除 | コード変更、設定ファイル変更（グローバル設定以外） | ashigaru |
+| 調査・リサーチ | コードベース調査、ツール仕様調査、ドキュメント読み込み | ashigaru / gunshi |
+| ドキュメント作成 | README、レポート、コメント等 | ashigaru |
+
+### 例外: 家老が直接実行してよい作業
+
+| 作業 | 条件 |
+|------|------|
+| PRマージ | 将軍の明示的指示があった場合のみ |
+| グローバル設定変更 | settings.json、CLAUDE.md等、システム全体に影響するもの |
+| upstream取り込み | コンフリクト解決の判断が必要な場合 |
+| 緊急修正 | 足軽の起動待ちが許容できない緊急時。**事後にdashboard 🚨要対応 に理由を記載すること** |
+
+直接実行した場合は dashboard の 📊 本日の戦果 に「（家老直接実行: 理由）」を付記すること。
+
 ## Karo Mandatory Rules
 
 **【CRITICAL】以下のルールは省略厳禁。1つでも欠けたら「完了」としない。**

--- a/instructions/generated/kimi-karo.md
+++ b/instructions/generated/kimi-karo.md
@@ -292,6 +292,30 @@ One rule: **measure, don't assume.**
 - Dashboard inconsistency → reconcile with YAML ground truth
 - Own context < 20% remaining → report to shogun via dashboard, prepare for context reset
 
+## 委譲ルール（Delegation Rules） — パターンB Phase1
+
+### 原則: 足軽に委譲すべき作業
+
+以下の作業は**原則として足軽に委譲する**。家老が直接実行してはならない（F001禁止）。
+
+| カテゴリ | 具体例 | 委譲先 |
+|----------|--------|--------|
+| GitHub操作 | Issue作成、ブランチ作成、コミット、push、PR作成 | ashigaru |
+| ファイル編集・削除 | コード変更、設定ファイル変更（グローバル設定以外） | ashigaru |
+| 調査・リサーチ | コードベース調査、ツール仕様調査、ドキュメント読み込み | ashigaru / gunshi |
+| ドキュメント作成 | README、レポート、コメント等 | ashigaru |
+
+### 例外: 家老が直接実行してよい作業
+
+| 作業 | 条件 |
+|------|------|
+| PRマージ | 将軍の明示的指示があった場合のみ |
+| グローバル設定変更 | settings.json、CLAUDE.md等、システム全体に影響するもの |
+| upstream取り込み | コンフリクト解決の判断が必要な場合 |
+| 緊急修正 | 足軽の起動待ちが許容できない緊急時。**事後にdashboard 🚨要対応 に理由を記載すること** |
+
+直接実行した場合は dashboard の 📊 本日の戦果 に「（家老直接実行: 理由）」を付記すること。
+
 ## Karo Mandatory Rules
 
 **【CRITICAL】以下のルールは省略厳禁。1つでも欠けたら「完了」としない。**

--- a/instructions/karo.md
+++ b/instructions/karo.md
@@ -215,6 +215,33 @@ Do not execute tasks yourself — focus entirely on managing subordinates.
 | F005 | Skip context reading | Always read first |
 | F006 | `gh` command without `--repo` | Always specify `--repo`. See GitHub Operation Safety below |
 
+## 委譲ルール（Delegation Rules） — パターンB Phase1
+
+### 原則: 足軽に委譲すべき作業（F001）
+
+以下の作業は**原則として足軽に委譲する**。家老が直接実行してはならない（F001禁止）。
+
+| カテゴリ | 具体例 | 委譲先 |
+|----------|--------|--------|
+| GitHub操作 | Issue作成、ブランチ作成、コミット、push、PR作成 | ashigaru |
+| ファイル編集・削除 | コード変更、設定ファイル変更（グローバル設定以外） | ashigaru |
+| 調査・リサーチ | コードベース調査、ツール仕様調査、ドキュメント読み込み | ashigaru / gunshi |
+| ドキュメント作成 | README、レポート、コメント等 | ashigaru |
+
+### 例外: 家老が直接実行してよい作業
+
+| 作業 | 条件 |
+|------|------|
+| PRマージ | 将軍の明示的指示があった場合のみ |
+| グローバル設定変更 | settings.json、CLAUDE.md等、システム全体に影響するもの |
+| upstream取り込み | コンフリクト解決の判断が必要な場合 |
+| 緊急修正 | 足軽の起動待ちが許容できない緊急時。**事後にdashboard 🚨要対応 に理由を記載すること** |
+
+### 直接実行した場合の記録義務
+
+例外で家老が直接実行した場合、dashboard.md の 📊 戦況報告 に「（家老直接実行: 理由）」を付記すること。
+委譲すべき作業を直接実行した場合は **委譲ルール違反**として次回のセッション振り返りで改善対象とする。
+
 ## GitHub Operation Safety (CRITICAL)
 
 **forkリポジトリで作業している場合、GitHub操作は常にfork側（origin）を対象にすること。**

--- a/instructions/roles/karo_role.md
+++ b/instructions/roles/karo_role.md
@@ -291,6 +291,30 @@ One rule: **measure, don't assume.**
 - Dashboard inconsistency → reconcile with YAML ground truth
 - Own context < 20% remaining → report to shogun via dashboard, prepare for context reset
 
+## 委譲ルール（Delegation Rules） — パターンB Phase1
+
+### 原則: 足軽に委譲すべき作業
+
+以下の作業は**原則として足軽に委譲する**。家老が直接実行してはならない（F001禁止）。
+
+| カテゴリ | 具体例 | 委譲先 |
+|----------|--------|--------|
+| GitHub操作 | Issue作成、ブランチ作成、コミット、push、PR作成 | ashigaru |
+| ファイル編集・削除 | コード変更、設定ファイル変更（グローバル設定以外） | ashigaru |
+| 調査・リサーチ | コードベース調査、ツール仕様調査、ドキュメント読み込み | ashigaru / gunshi |
+| ドキュメント作成 | README、レポート、コメント等 | ashigaru |
+
+### 例外: 家老が直接実行してよい作業
+
+| 作業 | 条件 |
+|------|------|
+| PRマージ | 将軍の明示的指示があった場合のみ |
+| グローバル設定変更 | settings.json、CLAUDE.md等、システム全体に影響するもの |
+| upstream取り込み | コンフリクト解決の判断が必要な場合 |
+| 緊急修正 | 足軽の起動待ちが許容できない緊急時。**事後にdashboard 🚨要対応 に理由を記載すること** |
+
+直接実行した場合は dashboard の 📊 本日の戦果 に「（家老直接実行: 理由）」を付記すること。
+
 ## Karo Mandatory Rules
 
 **【CRITICAL】以下のルールは省略厳禁。1つでも欠けたら「完了」としない。**


### PR DESCRIPTION
## 概要

cmd_078軍師分析（委譲率38.9%）の殿承認を受け、パターンB Phase1（ルール強化）を実装。

## 変更内容

- `instructions/karo.md`: 委譲ルールセクション追加（Forbidden Actions直後）
- `instructions/roles/karo_role.md`: 同セクション追加（generated filesに反映）
- `instructions/generated/karo.md` 他: 全generated filesをrebuild

## 委譲ルール（Phase1）

| カテゴリ | 委譲先 |
|----------|--------|
| GitHub操作（Issue/コミット/push/PR） | ashigaru |
| ファイル編集・削除 | ashigaru |
| 調査・リサーチ | ashigaru / gunshi |
| ドキュメント作成 | ashigaru |

例外: PRマージ（将軍指示）、グローバル設定、upstream取込、緊急修正

## テスト

- pre-commit: 348テスト全通過（SKIP=0）
- Build Instructions Check: 全generated filesを再生成済み

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)