### PR TITLE
feat: worktreeパイロット導入 — ashigaru worktreeフロー手順追加

### DIFF
--- a/instructions/generated/ashigaru.md
+++ b/instructions/generated/ashigaru.md
@@ -59,6 +59,31 @@ If conflict risk exists:
 
 **NEVER**: inject 「〜でござる」 into code, YAML, or technical documents. 戦国 style is for spoken output only.
 
+## Worktree Flow（use_worktree: true タスク）
+
+タスクYAMLに `use_worktree: true` が指定されている場合、以下のフローで作業せよ。
+
+### 手順
+
+1. **作業開始前に EnterWorktree を呼び出す**（ステップ3の直後）
+   - `name` にタスクIDを指定（例: `subtask-079a`）
+   - 新しいブランチが自動作成される
+   - セッションのCWDがworktreeに切り替わる
+
+2. **通常通り作業を実施する**（ファイル編集・コミット・push・PR作成）
+   - コミット前に `git status` でgit管理対象外ファイルが含まれていないか確認せよ
+   - `git add -f` は**絶対に使用禁止**（管理対象外ファイルを誤コミットする原因）
+
+3. **PR作成後に ExitWorktree を呼び出す**（action: "remove"）
+   - コミットされていない変更がある場合は先にコミットまたは破棄してから呼び出す
+
+### 注意事項
+
+- worktreeは `.claude/worktrees/` 配下に作成される
+- 各worktreeは独自ブランチを持つため、他のworktreeと干渉しない
+- EnterWorktreeはネスト不可（既にworktree内にいる場合はスキップ）
+- `git add -f` 使用禁止: git-ignoredファイルを誤コミットしたインシデントあり（2026-03-29）
+
 ## Autonomous Judgment Rules
 
 Act without waiting for Karo's instruction:

--- a/instructions/generated/codex-ashigaru.md
+++ b/instructions/generated/codex-ashigaru.md
@@ -59,6 +59,31 @@ If conflict risk exists:
 
 **NEVER**: inject 「〜でござる」 into code, YAML, or technical documents. 戦国 style is for spoken output only.
 
+## Worktree Flow（use_worktree: true タスク）
+
+タスクYAMLに `use_worktree: true` が指定されている場合、以下のフローで作業せよ。
+
+### 手順
+
+1. **作業開始前に EnterWorktree を呼び出す**（ステップ3の直後）
+   - `name` にタスクIDを指定（例: `subtask-079a`）
+   - 新しいブランチが自動作成される
+   - セッションのCWDがworktreeに切り替わる
+
+2. **通常通り作業を実施する**（ファイル編集・コミット・push・PR作成）
+   - コミット前に `git status` でgit管理対象外ファイルが含まれていないか確認せよ
+   - `git add -f` は**絶対に使用禁止**（管理対象外ファイルを誤コミットする原因）
+
+3. **PR作成後に ExitWorktree を呼び出す**（action: "remove"）
+   - コミットされていない変更がある場合は先にコミットまたは破棄してから呼び出す
+
+### 注意事項
+
+- worktreeは `.claude/worktrees/` 配下に作成される
+- 各worktreeは独自ブランチを持つため、他のworktreeと干渉しない
+- EnterWorktreeはネスト不可（既にworktree内にいる場合はスキップ）
+- `git add -f` 使用禁止: git-ignoredファイルを誤コミットしたインシデントあり（2026-03-29）
+
 ## Autonomous Judgment Rules
 
 Act without waiting for Karo's instruction:

--- a/instructions/generated/codex-karo.md
+++ b/instructions/generated/codex-karo.md
@@ -316,6 +316,19 @@ One rule: **measure, don't assume.**
 
 直接実行した場合は dashboard の 📊 本日の戦果 に「（家老直接実行: 理由）」を付記すること。
 
+### worktreeタスクの作成方法（Phase2）
+
+GitHub操作を含むタスクを足軽に委譲する際は `use_worktree: true` を指定すること:
+
+```yaml
+id: subtask_084a
+use_worktree: true        # 足軽がEnterWorktreeを使って独立ブランチで作業する
+description: |
+  【注意】use_worktree: true のため EnterWorktree → 作業 → PR → ExitWorktree(remove) のフローで実施せよ。
+```
+
+**コミット前の確認義務**: `git status` で確認。`git add -f` は絶対禁止（2026-03-29 PR#47インシデント）。
+
 ## Karo Mandatory Rules
 
 **【CRITICAL】以下のルールは省略厳禁。1つでも欠けたら「完了」としない。**

--- a/instructions/generated/copilot-ashigaru.md
+++ b/instructions/generated/copilot-ashigaru.md
@@ -59,6 +59,31 @@ If conflict risk exists:
 
 **NEVER**: inject 「〜でござる」 into code, YAML, or technical documents. 戦国 style is for spoken output only.
 
+## Worktree Flow（use_worktree: true タスク）
+
+タスクYAMLに `use_worktree: true` が指定されている場合、以下のフローで作業せよ。
+
+### 手順
+
+1. **作業開始前に EnterWorktree を呼び出す**（ステップ3の直後）
+   - `name` にタスクIDを指定（例: `subtask-079a`）
+   - 新しいブランチが自動作成される
+   - セッションのCWDがworktreeに切り替わる
+
+2. **通常通り作業を実施する**（ファイル編集・コミット・push・PR作成）
+   - コミット前に `git status` でgit管理対象外ファイルが含まれていないか確認せよ
+   - `git add -f` は**絶対に使用禁止**（管理対象外ファイルを誤コミットする原因）
+
+3. **PR作成後に ExitWorktree を呼び出す**（action: "remove"）
+   - コミットされていない変更がある場合は先にコミットまたは破棄してから呼び出す
+
+### 注意事項
+
+- worktreeは `.claude/worktrees/` 配下に作成される
+- 各worktreeは独自ブランチを持つため、他のworktreeと干渉しない
+- EnterWorktreeはネスト不可（既にworktree内にいる場合はスキップ）
+- `git add -f` 使用禁止: git-ignoredファイルを誤コミットしたインシデントあり（2026-03-29）
+
 ## Autonomous Judgment Rules
 
 Act without waiting for Karo's instruction:

--- a/instructions/generated/copilot-karo.md
+++ b/instructions/generated/copilot-karo.md
@@ -316,6 +316,19 @@ One rule: **measure, don't assume.**
 
 直接実行した場合は dashboard の 📊 本日の戦果 に「（家老直接実行: 理由）」を付記すること。
 
+### worktreeタスクの作成方法（Phase2）
+
+GitHub操作を含むタスクを足軽に委譲する際は `use_worktree: true` を指定すること:
+
+```yaml
+id: subtask_084a
+use_worktree: true        # 足軽がEnterWorktreeを使って独立ブランチで作業する
+description: |
+  【注意】use_worktree: true のため EnterWorktree → 作業 → PR → ExitWorktree(remove) のフローで実施せよ。
+```
+
+**コミット前の確認義務**: `git status` で確認。`git add -f` は絶対禁止（2026-03-29 PR#47インシデント）。
+
 ## Karo Mandatory Rules
 
 **【CRITICAL】以下のルールは省略厳禁。1つでも欠けたら「完了」としない。**

--- a/instructions/generated/karo.md
+++ b/instructions/generated/karo.md
@@ -316,6 +316,19 @@ One rule: **measure, don't assume.**
 
 直接実行した場合は dashboard の 📊 本日の戦果 に「（家老直接実行: 理由）」を付記すること。
 
+### worktreeタスクの作成方法（Phase2）
+
+GitHub操作を含むタスクを足軽に委譲する際は `use_worktree: true` を指定すること:
+
+```yaml
+id: subtask_084a
+use_worktree: true        # 足軽がEnterWorktreeを使って独立ブランチで作業する
+description: |
+  【注意】use_worktree: true のため EnterWorktree → 作業 → PR → ExitWorktree(remove) のフローで実施せよ。
+```
+
+**コミット前の確認義務**: `git status` で確認。`git add -f` は絶対禁止（2026-03-29 PR#47インシデント）。
+
 ## Karo Mandatory Rules
 
 **【CRITICAL】以下のルールは省略厳禁。1つでも欠けたら「完了」としない。**

--- a/instructions/generated/kimi-ashigaru.md
+++ b/instructions/generated/kimi-ashigaru.md
@@ -59,6 +59,31 @@ If conflict risk exists:
 
 **NEVER**: inject 「〜でござる」 into code, YAML, or technical documents. 戦国 style is for spoken output only.
 
+## Worktree Flow（use_worktree: true タスク）
+
+タスクYAMLに `use_worktree: true` が指定されている場合、以下のフローで作業せよ。
+
+### 手順
+
+1. **作業開始前に EnterWorktree を呼び出す**（ステップ3の直後）
+   - `name` にタスクIDを指定（例: `subtask-079a`）
+   - 新しいブランチが自動作成される
+   - セッションのCWDがworktreeに切り替わる
+
+2. **通常通り作業を実施する**（ファイル編集・コミット・push・PR作成）
+   - コミット前に `git status` でgit管理対象外ファイルが含まれていないか確認せよ
+   - `git add -f` は**絶対に使用禁止**（管理対象外ファイルを誤コミットする原因）
+
+3. **PR作成後に ExitWorktree を呼び出す**（action: "remove"）
+   - コミットされていない変更がある場合は先にコミットまたは破棄してから呼び出す
+
+### 注意事項
+
+- worktreeは `.claude/worktrees/` 配下に作成される
+- 各worktreeは独自ブランチを持つため、他のworktreeと干渉しない
+- EnterWorktreeはネスト不可（既にworktree内にいる場合はスキップ）
+- `git add -f` 使用禁止: git-ignoredファイルを誤コミットしたインシデントあり（2026-03-29）
+
 ## Autonomous Judgment Rules
 
 Act without waiting for Karo's instruction:

--- a/instructions/generated/kimi-karo.md
+++ b/instructions/generated/kimi-karo.md
@@ -316,6 +316,19 @@ One rule: **measure, don't assume.**
 
 直接実行した場合は dashboard の 📊 本日の戦果 に「（家老直接実行: 理由）」を付記すること。
 
+### worktreeタスクの作成方法（Phase2）
+
+GitHub操作を含むタスクを足軽に委譲する際は `use_worktree: true` を指定すること:
+
+```yaml
+id: subtask_084a
+use_worktree: true        # 足軽がEnterWorktreeを使って独立ブランチで作業する
+description: |
+  【注意】use_worktree: true のため EnterWorktree → 作業 → PR → ExitWorktree(remove) のフローで実施せよ。
+```
+
+**コミット前の確認義務**: `git status` で確認。`git add -f` は絶対禁止（2026-03-29 PR#47インシデント）。
+
 ## Karo Mandatory Rules
 
 **【CRITICAL】以下のルールは省略厳禁。1つでも欠けたら「完了」としない。**

--- a/instructions/karo.md
+++ b/instructions/karo.md
@@ -242,6 +242,28 @@ Do not execute tasks yourself — focus entirely on managing subordinates.
 例外で家老が直接実行した場合、dashboard.md の 📊 戦況報告 に「（家老直接実行: 理由）」を付記すること。
 委譲すべき作業を直接実行した場合は **委譲ルール違反**として次回のセッション振り返りで改善対象とする。
 
+### worktreeタスクの作成方法（Phase2）
+
+GitHub操作を含むタスクを足軽に委譲する際は `use_worktree: true` を指定すること:
+
+```yaml
+id: subtask_084a
+type: subtask
+status: assigned
+assigned_to: ashigaru1
+use_worktree: true        # 足軽がEnterWorktreeを使って独立ブランチで作業する
+project: multi-agent-shogun
+description: |
+  [作業内容]
+  ...
+  【注意】use_worktree: true のため、作業開始前に EnterWorktree を呼び出すこと。
+  PR作成後に ExitWorktree(action: "remove") を呼び出すこと。
+```
+
+**コミット前の確認義務（`git add -f` 禁止）**:
+足軽（および家老）がコミットする前に `git status` で確認せよ。
+`git add -f` はgit管理対象外ファイルを誤コミットする原因となるため**絶対禁止**（2026-03-29 PR#47インシデント）。
+
 ## GitHub Operation Safety (CRITICAL)
 
 **forkリポジトリで作業している場合、GitHub操作は常にfork側（origin）を対象にすること。**

--- a/instructions/roles/ashigaru_role.md
+++ b/instructions/roles/ashigaru_role.md
@@ -58,6 +58,31 @@ If conflict risk exists:
 
 **NEVER**: inject 「〜でござる」 into code, YAML, or technical documents. 戦国 style is for spoken output only.
 
+## Worktree Flow（use_worktree: true タスク）
+
+タスクYAMLに `use_worktree: true` が指定されている場合、以下のフローで作業せよ。
+
+### 手順
+
+1. **作業開始前に EnterWorktree を呼び出す**（ステップ3の直後）
+   - `name` にタスクIDを指定（例: `subtask-079a`）
+   - 新しいブランチが自動作成される
+   - セッションのCWDがworktreeに切り替わる
+
+2. **通常通り作業を実施する**（ファイル編集・コミット・push・PR作成）
+   - コミット前に `git status` でgit管理対象外ファイルが含まれていないか確認せよ
+   - `git add -f` は**絶対に使用禁止**（管理対象外ファイルを誤コミットする原因）
+
+3. **PR作成後に ExitWorktree を呼び出す**（action: "remove"）
+   - コミットされていない変更がある場合は先にコミットまたは破棄してから呼び出す
+
+### 注意事項
+
+- worktreeは `.claude/worktrees/` 配下に作成される
+- 各worktreeは独自ブランチを持つため、他のworktreeと干渉しない
+- EnterWorktreeはネスト不可（既にworktree内にいる場合はスキップ）
+- `git add -f` 使用禁止: git-ignoredファイルを誤コミットしたインシデントあり（2026-03-29）
+
 ## Autonomous Judgment Rules
 
 Act without waiting for Karo's instruction:

--- a/instructions/roles/karo_role.md
+++ b/instructions/roles/karo_role.md
@@ -315,6 +315,19 @@ One rule: **measure, don't assume.**
 
 直接実行した場合は dashboard の 📊 本日の戦果 に「（家老直接実行: 理由）」を付記すること。
 
+### worktreeタスクの作成方法（Phase2）
+
+GitHub操作を含むタスクを足軽に委譲する際は `use_worktree: true` を指定すること:
+
+```yaml
+id: subtask_084a
+use_worktree: true        # 足軽がEnterWorktreeを使って独立ブランチで作業する
+description: |
+  【注意】use_worktree: true のため EnterWorktree → 作業 → PR → ExitWorktree(remove) のフローで実施せよ。
+```
+
+**コミット前の確認義務**: `git status` で確認。`git add -f` は絶対禁止（2026-03-29 PR#47インシデント）。
+
 ## Karo Mandatory Rules
 
 **【CRITICAL】以下のルールは省略厳禁。1つでも欠けたら「完了」としない。**


### PR DESCRIPTION
## 概要

パターンB Phase2: git worktreeによる並行作業フローをashigaruに導入。

## 変更内容

- `instructions/roles/ashigaru_role.md`: Worktree Flowセクション追加
  - `use_worktree: true` タスクのフロー（EnterWorktree → 作業 → ExitWorktree）
  - `git add -f` 禁止ルール（2026-03-29 PR#47インシデント記録）
- `instructions/roles/karo_role.md`: worktreeタスク作成方法追記
- `instructions/karo.md`: 同上（直接編集）
- `instructions/generated/`: 全generated filesをrebuild

## パイロットテスト

ashigaru1に `subtask_084a` を割り当て済み（`use_worktree: true`）。
完了後、worktreeフローの動作を確認する。

## テスト

- pre-commit: 348テスト全通過（SKIP=0）

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)