### PR TITLE
bloom_levelベース強制委譲・QC自動トリガーシステム

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@
 !scripts/ratelimit_check.sh
 !scripts/switch_cli.sh
 !scripts/compact_statusline.sh
+!scripts/validate_delegation.sh
 
 # Tools (version-controlled hooks etc.)
 !tools/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,15 @@ mcp_usage: "Lazy-loaded. Always ToolSearch before first use."
 parallel_principle: "足軽は可能な限り並列投入。家老は統括専念。1人抱え込み禁止。"
 std_process: "Strategy→Spec→Test→Implement→Verify を全cmdの標準手順とする"
 critical_thinking_principle: "家老・足軽は盲目的に従わず前提を検証し、代替案を提案する。ただし過剰批判で停止せず、実行可能性とのバランスを保つ。"
-bloom_routing_rule: "config/settings.yamlのbloom_routing設定を確認せよ。autoなら家老はStep 6.5（Bloom Taxonomy L1-L6モデルルーティング）を必ず実行。スキップ厳禁。"
+bloom_routing_rule: |
+  config/settings.yaml の bloom_routing/bloom_delegation/qc_trigger 設定を確認せよ。
+  bloom_routing=auto の場合:
+  - 家老は bloom_level に基づいて委譲先を【強制的に】決定する
+  - L1-L4 → 足軽に委譲（家老の直接実行はF001違反）
+  - L5-L6 → 軍師に委譲
+  - L4以上の完了タスク → 軍師QC必須（QCレポートなしにdone禁止）
+  - 家老直接実行の例外: PRマージ、グローバル設定、upstream取り込み、緊急修正のみ
+  bloom_delegation_enforcement: true
 
 language:
   ja: "戦国風日本語のみ。「はっ！」「承知つかまつった」「任務完了でござる」"

--- a/instructions/gunshi.md
+++ b/instructions/gunshi.md
@@ -209,6 +209,17 @@ Karo makes final OK/NG decision and unblocks next tasks
 - If task has build → build must complete successfully
 - Scope matches original task YAML description
 
+**QC深度 — bloom_levelに基づく分類:**
+
+| bloom_level | QC深度 | チェック内容 |
+|-------------|--------|-------------|
+| L1-L3 | 簡易QC | deliverable存在確認、スコープ一致、明らかなエラー検出。所要時間: 最小限 |
+| L4 | 標準QC | 上記 + コード品質確認、テスト網羅性、実装の妥当性 |
+| L5-L6 | 深いQC | 上記 + 設計判断の妥当性検証、代替案の検討、アーキテクチャ整合性 |
+
+config/settings.yaml の `qc_trigger.gunshi_qc_threshold` (デフォルト: 4) 以上のbloom_levelを持つタスクは、
+軍師QCなしに家老がdoneにすることは禁止されている。QCレポートは必ず作成すること。
+
 **Concerns to Flag in Report:**
 - Missing files or incomplete deliverables
 - Test failures or skips (use SKIP = FAIL rule)

--- a/instructions/karo.md
+++ b/instructions/karo.md
@@ -41,6 +41,34 @@ workflow:
   - step: 2
     action: read_yaml
     target: queue/shogun_to_karo.yaml
+  - step: 2.5
+    action: bloom_level_check
+    mandatory: true
+    note: |
+      【必須 — スキップ厳禁】bloom_level検証と委譲先決定。
+
+      1. cmdに bloom_level フィールドがあるか確認
+      2. bloom_levelがない場合 → 家老自身が判断して付与する
+         判断基準: 「創造性・判断が要るか？」→ YES=L4以上、NO=L3以下
+      3. config/settings.yaml の bloom_delegation 設定に基づき委譲先を決定:
+
+      | bloom_level | 委譲先 | 家老の行動 |
+      |-------------|--------|-----------|
+      | L1-L4 | 足軽（ashigaru） | **足軽に委譲しなければならない。自分で実装禁止。** |
+      | L5-L6 | 軍師（gunshi） | **軍師に戦略分析/設計/QCを依頼。** |
+      | 例外のみ | 家老直接 | karo_direct_exceptions に該当する場合のみ |
+
+      【CRITICAL: F001強化】
+      bloom_level L1-L4のタスクを家老が直接実行することは F001重大違反 である。
+      「足軽の起動を待つのが面倒」「自分でやった方が早い」は理由にならない。
+      違反した場合、dashboard.md 🚨要対応セクションに自動記録される。
+
+      着手前チェックリスト（タスクに触れる前に必ず自問）:
+      - [ ] このタスクのbloom_levelは？
+      - [ ] L1-L4なら、足軽に委譲したか？
+      - [ ] L5-L6なら、軍師に依頼したか？
+      - [ ] karo_direct_exceptions に該当するか？
+      チェックリストを通過せずにタスクを実行開始してはならない。
   - step: 3
     action: update_dashboard
     target: dashboard.md
@@ -215,32 +243,41 @@ Do not execute tasks yourself — focus entirely on managing subordinates.
 | F005 | Skip context reading | Always read first |
 | F006 | `gh` command without `--repo` | Always specify `--repo`. See GitHub Operation Safety below |
 
-## 委譲ルール（Delegation Rules） — パターンB Phase1
+## 委譲ルール（Delegation Rules） — bloom_level強制ルーティング
 
-### 原則: 足軽に委譲すべき作業（F001）
+### 【絶対ルール】bloom_levelによる委譲先決定
 
-以下の作業は**原則として足軽に委譲する**。家老が直接実行してはならない（F001禁止）。
+config/settings.yaml の bloom_delegation 設定に従う。**これは推奨ではなく強制である。**
 
-| カテゴリ | 具体例 | 委譲先 |
-|----------|--------|--------|
-| GitHub操作 | Issue作成、ブランチ作成、コミット、push、PR作成 | ashigaru |
-| ファイル編集・削除 | コード変更、設定ファイル変更（グローバル設定以外） | ashigaru |
-| 調査・リサーチ | コードベース調査、ツール仕様調査、ドキュメント読み込み | ashigaru / gunshi |
-| ドキュメント作成 | README、レポート、コメント等 | ashigaru |
+| bloom_level | 委譲先 | 根拠 |
+|-------------|--------|------|
+| L1-L3 | 足軽（ashigaru） | 記憶・理解・機械的適用 — 足軽で十分 |
+| L4 | 足軽（ashigaru） | 創造的適用（実装）— 足軽が実行、完了後に軍師QC |
+| L5-L6 | 軍師（gunshi） | 分析・評価・戦略設計 — 軍師の専門領域 |
 
-### 例外: 家老が直接実行してよい作業
+### 家老が直接実行してよいケース（これ以外は全て委譲）
 
 | 作業 | 条件 |
 |------|------|
 | PRマージ | 将軍の明示的指示があった場合のみ |
-| グローバル設定変更 | settings.json、CLAUDE.md等、システム全体に影響するもの |
+| グローバル設定変更 | settings.yaml、CLAUDE.md等、システム全体に影響するもの |
 | upstream取り込み | コンフリクト解決の判断が必要な場合 |
-| 緊急修正 | 足軽の起動待ちが許容できない緊急時。**事後にdashboard 🚨要対応 に理由を記載すること** |
+| 緊急修正 | 足軽の起動待ちが5分以上かかり、かつ将軍が即時対応を求めている場合。**事後にdashboard 🚨要対応 に理由を記載必須** |
+
+### F001違反の定義と記録（CRITICAL）
+
+**上記例外以外のL1-L4タスクを家老が直接実行した場合 = F001重大違反。**
+
+違反時の処理:
+1. dashboard.md 🚨要対応セクションに「F001違反: {cmd_id} を家老が直接実行。理由: {理由}」を記録
+2. 将軍がntfy経由で通知を受ける
+3. 次回以降の改善対象として追跡される
+
+**「自分でやった方が早い」「足軽が遊んでいるのに気づかなかった」は違反の免責事由にならない。**
 
 ### 直接実行した場合の記録義務
 
-例外で家老が直接実行した場合、dashboard.md の 📊 戦況報告 に「（家老直接実行: 理由）」を付記すること。
-委譲すべき作業を直接実行した場合は **委譲ルール違反**として次回のセッション振り返りで改善対象とする。
+例外で家老が正当に直接実行した場合も、dashboard.md の 📊 戦況報告 に「（家老直接実行: 理由）」を付記すること。
 
 ### worktreeタスクの作成方法（Phase2）
 
@@ -568,8 +605,13 @@ Push notifications to the lord's phone via ntfy. Karo manages streaks and notifi
 1. Get `parent_cmd` of completed subtask
 2. Check all subtasks with same `parent_cmd`: `grep -l "parent_cmd: cmd_XXX" queue/tasks/ashigaru*.yaml | xargs grep "status:"`
 3. Not all done → skip step 13 (ntfy_gate)
-4. All done → **purpose validation**: Re-read the original cmd in `queue/shogun_to_karo.yaml`. Compare the cmd's stated purpose against the combined deliverables. If purpose is not achieved (subtasks completed but goal unmet), do NOT mark cmd as done — instead create additional subtasks or report the gap to shogun via dashboard 🚨.
-5. **Purpose validated → update `queue/shogun_to_karo.yaml`**: Set `status: done` and add `completed_at: '<timestamp>'` for the cmd entry.
+4. **【QCゲート — bloom_levelベース】** All subtasks done → QCレポートの存在を確認:
+   - 各サブタスクの bloom_level を確認
+   - **L4以上のサブタスクについて**: `queue/reports/{task_id}_qc.yaml` が存在し、`reviewed_by: gunshi` が記載されているか確認
+   - **QCレポートが存在しないL4以上のサブタスクがある場合** → cmdをdoneにしない。軍師にQCを依頼するタスクを作成し、inbox_writeで通知する
+   - L1-L3のサブタスクのみの場合 → 軍師QCは不要（家老の簡易確認で可）
+5. QCゲート通過 → **purpose validation**: Re-read the original cmd in `queue/shogun_to_karo.yaml`. Compare the cmd's stated purpose against the combined deliverables. If purpose is not achieved (subtasks completed but goal unmet), do NOT mark cmd as done — instead create additional subtasks or report the gap to shogun via dashboard 🚨.
+6. **Purpose validated → update `queue/shogun_to_karo.yaml`**: Set `status: done` and add `completed_at: '<timestamp>'` for the cmd entry.
 6. Update `saytask/streaks.yaml`:
    - `today.completed` += 1 (**per cmd**, not per subtask)
    - Streak logic: last_date=today → keep current; last_date=yesterday → current+1; else → reset to 1

--- a/scripts/validate_delegation.sh
+++ b/scripts/validate_delegation.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# validate_delegation.sh — bloom_level委譲ルール違反検知スクリプト
+#
+# Usage: bash scripts/validate_delegation.sh [--report] [--cmd CMD_ID]
+#
+# チェック項目:
+#   1. bloom_level欠如（タスクYAML）
+#   2. L1-L4タスクの足軽未委譲（家老直接実行疑い）
+#   3. L4以上タスクの軍師QCレポート欠如
+#   4. cmdに紐づくサブタスクが0件（家老直接実行疑い）
+
+set -euo pipefail
+
+QUEUE_DIR="$(cd "$(dirname "$0")/.." && pwd)/queue"
+TASKS_DIR="$QUEUE_DIR/tasks"
+REPORTS_DIR="$QUEUE_DIR/reports"
+
+# Parse args
+REPORT_MODE=false
+TARGET_CMD=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --report) REPORT_MODE=true; shift ;;
+        --cmd) TARGET_CMD="$2"; shift 2 ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+violations=0
+warnings=0
+
+warn() {
+    echo "WARNING: $1"
+    ((warnings++)) || true
+}
+
+violation() {
+    echo "VIOLATION: $1"
+    ((violations++)) || true
+}
+
+info() {
+    echo "INFO: $1"
+}
+
+# Extract bloom_level numeric value from a YAML file
+get_bloom_level() {
+    local file="$1"
+    local bl
+    bl=$(grep -oP 'bloom_level:\s*L?(\d+)' "$file" 2>/dev/null | grep -oP '\d+' | head -1)
+    echo "${bl:-0}"
+}
+
+echo "=== bloom_level Delegation Validation ==="
+echo "Date: $(date '+%Y-%m-%d %H:%M:%S')"
+echo ""
+
+# --- Check 1: cmd YAMLs without bloom_level ---
+echo "--- Check 1: bloom_level presence in cmd YAMLs ---"
+for cmd_file in "$TASKS_DIR"/cmd_*.yaml; do
+    [[ -f "$cmd_file" ]] || continue
+    cmd_id=$(basename "$cmd_file" .yaml)
+
+    # Skip if targeting specific cmd
+    [[ -n "$TARGET_CMD" && "$cmd_id" != "$TARGET_CMD" ]] && continue
+
+    if ! grep -q 'bloom_level:' "$cmd_file" 2>/dev/null; then
+        warn "$cmd_id: bloom_level フィールドなし"
+    fi
+done
+echo ""
+
+# --- Check 2: cmd assigned_to karo but bloom_level is L1-L4 ---
+echo "--- Check 2: L1-L4 tasks assigned to karo (F001 violation) ---"
+for cmd_file in "$TASKS_DIR"/cmd_*.yaml; do
+    [[ -f "$cmd_file" ]] || continue
+    cmd_id=$(basename "$cmd_file" .yaml)
+
+    [[ -n "$TARGET_CMD" && "$cmd_id" != "$TARGET_CMD" ]] && continue
+
+    assigned=$(grep -oP 'assigned_to:\s*(\S+)' "$cmd_file" 2>/dev/null | awk '{print $2}')
+    bl=$(get_bloom_level "$cmd_file")
+
+    if [[ "$assigned" == "karo" && "$bl" -ge 1 && "$bl" -le 4 ]]; then
+        # Check if there are subtasks for this cmd (ashigaru delegation)
+        subtask_count=0
+        for ashigaru_file in "$TASKS_DIR"/ashigaru*.yaml; do
+            [[ -f "$ashigaru_file" ]] || continue
+            if grep -q "parent_cmd: $cmd_id" "$ashigaru_file" 2>/dev/null; then
+                ((subtask_count++)) || true
+            fi
+        done
+
+        if [[ $subtask_count -eq 0 ]]; then
+            violation "$cmd_id: bloom_level L$bl (足軽範囲) だが家老に割当済み、サブタスク0件 → F001違反の疑い"
+        else
+            info "$cmd_id: bloom_level L$bl, 家老割当だがサブタスク${subtask_count}件あり（委譲済み）"
+        fi
+    fi
+done
+echo ""
+
+# --- Check 3: L4+ tasks without gunshi QC report ---
+echo "--- Check 3: L4+ tasks missing gunshi QC report ---"
+for cmd_file in "$TASKS_DIR"/cmd_*.yaml; do
+    [[ -f "$cmd_file" ]] || continue
+    cmd_id=$(basename "$cmd_file" .yaml)
+
+    [[ -n "$TARGET_CMD" && "$cmd_id" != "$TARGET_CMD" ]] && continue
+
+    status=$(grep -oP 'status:\s*(\S+)' "$cmd_file" 2>/dev/null | awk '{print $2}')
+    [[ "$status" != "done" ]] && continue
+
+    bl=$(get_bloom_level "$cmd_file")
+    [[ "$bl" -lt 4 ]] && continue
+
+    # Check for QC report
+    qc_file="$REPORTS_DIR/${cmd_id}_qc.yaml"
+    if [[ ! -f "$qc_file" ]]; then
+        violation "$cmd_id: bloom_level L$bl (QC必須) だが軍師QCレポートなし (${cmd_id}_qc.yaml)"
+    else
+        if ! grep -q 'reviewed_by: gunshi' "$qc_file" 2>/dev/null; then
+            violation "$cmd_id: QCレポート存在するが reviewed_by: gunshi がない"
+        else
+            info "$cmd_id: bloom_level L$bl, 軍師QCレポート確認済み"
+        fi
+    fi
+done
+echo ""
+
+# --- Check 4: Done cmds with no subtasks at all ---
+echo "--- Check 4: Done cmds with zero subtasks (direct execution) ---"
+for cmd_file in "$TASKS_DIR"/cmd_*.yaml; do
+    [[ -f "$cmd_file" ]] || continue
+    cmd_id=$(basename "$cmd_file" .yaml)
+
+    [[ -n "$TARGET_CMD" && "$cmd_id" != "$TARGET_CMD" ]] && continue
+
+    status=$(grep -oP 'status:\s*(\S+)' "$cmd_file" 2>/dev/null | awk '{print $2}')
+    [[ "$status" != "done" ]] && continue
+
+    subtask_count=0
+    for ashigaru_file in "$TASKS_DIR"/ashigaru*.yaml "$TASKS_DIR"/subtask_*.yaml; do
+        [[ -f "$ashigaru_file" ]] || continue
+        if grep -q "parent_cmd: $cmd_id" "$ashigaru_file" 2>/dev/null; then
+            ((subtask_count++)) || true
+        fi
+    done
+
+    # Also check gunshi tasks
+    if [[ -f "$TASKS_DIR/gunshi.yaml" ]]; then
+        if grep -q "parent_cmd: $cmd_id" "$TASKS_DIR/gunshi.yaml" 2>/dev/null; then
+            ((subtask_count++)) || true
+        fi
+    fi
+
+    if [[ $subtask_count -eq 0 ]]; then
+        warn "$cmd_id: 完了済みだがサブタスク0件 → 家老直接実行の可能性"
+    fi
+done
+echo ""
+
+# --- Summary ---
+echo "=== Summary ==="
+echo "Violations: $violations"
+echo "Warnings:   $warnings"
+
+if [[ $violations -gt 0 ]]; then
+    echo ""
+    echo "RESULT: FAIL — $violations 件の委譲ルール違反を検出"
+    exit 1
+elif [[ $warnings -gt 0 ]]; then
+    echo ""
+    echo "RESULT: WARN — 違反なし、$warnings 件の警告あり"
+    exit 0
+else
+    echo ""
+    echo "RESULT: PASS — 違反・警告なし"
+    exit 0
+fi


### PR DESCRIPTION
## Summary

- bloom_levelに基づく足軽/軍師への強制委譲ルールを導入（家老の直接実行をF001違反として検知）
- L4以上のタスク完了時に軍師QCを必須化（QCレポートなしにdone禁止）
- 違反検知スクリプト `validate_delegation.sh` を新規作成

Closes #62

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `config/settings.yaml` | `bloom_routing`, `bloom_delegation`, `qc_trigger` 設定追加 |
| `instructions/karo.md` | Step 2.5新設、委譲ルール強制化、Step 12 QCゲート追加 |
| `instructions/gunshi.md` | QC深度ルール追加（L1-L3簡易 / L4標準 / L5-L6深い） |
| `CLAUDE.md` | `bloom_routing_rule` 強化 |
| `scripts/validate_delegation.sh` | 委譲ルール違反検知スクリプト新規作成 |
| `.gitignore` | 上記2ファイルをホワイトリストに追加 |

## Test plan

- [x] pre-commitフック全チェック通過（bats 348テスト + ShellCheck）
- [x] `validate_delegation.sh --cmd cmd_114` が家老直接実行を検出することを確認
- [ ] 次回cmd発令時に家老が足軽に委譲するか観察

🤖 Generated with [Claude Code](https://claude.com/claude-code)