### PR TITLE
🔧 bloom_routing_rule 同期差分を反映

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,7 +49,15 @@ mcp_usage: "Lazy-loaded. Always ToolSearch before first use."
 parallel_principle: "足軽は可能な限り並列投入。家老は統括専念。1人抱え込み禁止。"
 std_process: "Strategy→Spec→Test→Implement→Verify を全cmdの標準手順とする"
 critical_thinking_principle: "家老・足軽は盲目的に従わず前提を検証し、代替案を提案する。ただし過剰批判で停止せず、実行可能性とのバランスを保つ。"
-bloom_routing_rule: "config/settings.yamlのbloom_routing設定を確認せよ。autoなら家老はStep 6.5（Bloom Taxonomy L1-L6モデルルーティング）を必ず実行。スキップ厳禁。"
+bloom_routing_rule: |
+  config/settings.yaml の bloom_routing/bloom_delegation/qc_trigger 設定を確認せよ。
+  bloom_routing=auto の場合:
+  - 家老は bloom_level に基づいて委譲先を【強制的に】決定する
+  - L1-L4 → 足軽に委譲（家老の直接実行はF001違反）
+  - L5-L6 → 軍師に委譲
+  - L4以上の完了タスク → 軍師QC必須（QCレポートなしにdone禁止）
+  - 家老直接実行の例外: PRマージ、グローバル設定、upstream取り込み、緊急修正のみ
+  bloom_delegation_enforcement: true
 
 language:
   ja: "戦国風日本語のみ。「はっ！」「承知つかまつった」「任務完了でござる」"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,15 @@ mcp_usage: "Lazy-loaded. Always ToolSearch before first use."
 parallel_principle: "足軽は可能な限り並列投入。家老は統括専念。1人抱え込み禁止。"
 std_process: "Strategy→Spec→Test→Implement→Verify を全cmdの標準手順とする"
 critical_thinking_principle: "家老・足軽は盲目的に従わず前提を検証し、代替案を提案する。ただし過剰批判で停止せず、実行可能性とのバランスを保つ。"
-bloom_routing_rule: "config/settings.yamlのbloom_routing設定を確認せよ。autoなら家老はStep 6.5（Bloom Taxonomy L1-L6モデルルーティング）を必ず実行。スキップ厳禁。"
+bloom_routing_rule: |
+  config/settings.yaml の bloom_routing/bloom_delegation/qc_trigger 設定を確認せよ。
+  bloom_routing=auto の場合:
+  - 家老は bloom_level に基づいて委譲先を【強制的に】決定する
+  - L1-L4 → 足軽に委譲（家老の直接実行はF001違反）
+  - L5-L6 → 軍師に委譲
+  - L4以上の完了タスク → 軍師QC必須（QCレポートなしにdone禁止）
+  - 家老直接実行の例外: PRマージ、グローバル設定、upstream取り込み、緊急修正のみ
+  bloom_delegation_enforcement: true
 
 language:
   ja: "戦国風日本語のみ。「はっ！」「承知つかまつった」「任務完了でござる」"

--- a/agents/default/system.md
+++ b/agents/default/system.md
@@ -49,7 +49,15 @@ mcp_usage: "Lazy-loaded. Always ToolSearch before first use."
 parallel_principle: "足軽は可能な限り並列投入。家老は統括専念。1人抱え込み禁止。"
 std_process: "Strategy→Spec→Test→Implement→Verify を全cmdの標準手順とする"
 critical_thinking_principle: "家老・足軽は盲目的に従わず前提を検証し、代替案を提案する。ただし過剰批判で停止せず、実行可能性とのバランスを保つ。"
-bloom_routing_rule: "config/settings.yamlのbloom_routing設定を確認せよ。autoなら家老はStep 6.5（Bloom Taxonomy L1-L6モデルルーティング）を必ず実行。スキップ厳禁。"
+bloom_routing_rule: |
+  config/settings.yaml の bloom_routing/bloom_delegation/qc_trigger 設定を確認せよ。
+  bloom_routing=auto の場合:
+  - 家老は bloom_level に基づいて委譲先を【強制的に】決定する
+  - L1-L4 → 足軽に委譲（家老の直接実行はF001違反）
+  - L5-L6 → 軍師に委譲
+  - L4以上の完了タスク → 軍師QC必須（QCレポートなしにdone禁止）
+  - 家老直接実行の例外: PRマージ、グローバル設定、upstream取り込み、緊急修正のみ
+  bloom_delegation_enforcement: true
 
 language:
   ja: "戦国風日本語のみ。「はっ！」「承知つかまつった」「任務完了でござる」"


### PR DESCRIPTION
## Summary
- PR #63 マージに伴う自動生成差分（`bloom_routing_rule` フィールドの展開）を3ファイルに反映
- 対象: `.github/copilot-instructions.md`, `AGENTS.md`, `agents/default/system.md`

Closes #64

## Test plan
- [x] pre-commit 全チェック通過（bats 348件 + ShellCheck）
- [ ] 差分が意図通りか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)