### PR TITLE
feat(stop-hook): bloom_level L4以上タスクの軍師QCゲート強制チェック (close #66)

### DIFF
--- a/instructions/karo.md
+++ b/instructions/karo.md
@@ -606,6 +606,11 @@ Push notifications to the lord's phone via ntfy. Karo manages streaks and notifi
 2. Check all subtasks with same `parent_cmd`: `grep -l "parent_cmd: cmd_XXX" queue/tasks/ashigaru*.yaml | xargs grep "status:"`
 3. Not all done → skip step 13 (ntfy_gate)
 4. **【QCゲート — bloom_levelベース】** All subtasks done → QCレポートの存在を確認:
+
+   > ⚠️ 絶対遵守: QCゲートのスキップは禁止
+   > bloom_level L4以上のサブタスクがdoneの場合、queue/reports/{task_id}_qc.yaml（reviewed_by: gunshi）の
+   > 存在を確認するまで絶対にcmdをdoneにしてはならない。
+   > stop_hookがこのルールを機械的に検証する。スキップした場合はstop_hookでブロックされる。
    - 各サブタスクの bloom_level を確認
    - **L4以上のサブタスクについて**: `queue/reports/{task_id}_qc.yaml` が存在し、`reviewed_by: gunshi` が記載されているか確認
    - **QCレポートが存在しないL4以上のサブタスクがある場合** → cmdをdoneにしない。軍師にQCを依頼するタスクを作成し、inbox_writeで通知する

--- a/scripts/stop_hook_inbox.sh
+++ b/scripts/stop_hook_inbox.sh
@@ -161,34 +161,14 @@ print(json.dumps({'decision': 'block', 'reason': reason}, ensure_ascii=False))
     QC_MISSING=""
     for yaml in "$SCRIPT_DIR/queue/tasks/ashigaru"*.yaml; do
         [ -f "$yaml" ] || continue
-        STATUS=$(python3 -c "
-import sys, yaml as y
-try:
-    d = y.safe_load(open('$yaml'))
-    t = d.get('task', d) if d else {}
-    print(t.get('status', ''))
-except: pass
-" 2>/dev/null || true)
+        # PyYAML非依存: grep/sedでYAMLフィールドを抽出（macOS互換）
+        STATUS=$(grep -E '^\s*status:' "$yaml" | head -1 | sed 's/^.*status:[[:space:]]*//' | tr -d '"' | tr -d "'" | xargs)
         [ "$STATUS" = "done" ] || continue
-        BLOOM=$(python3 -c "
-import sys, yaml as y
-try:
-    d = y.safe_load(open('$yaml'))
-    t = d.get('task', d) if d else {}
-    print(t.get('bloom_level', ''))
-except: pass
-" 2>/dev/null || true)
+        BLOOM=$(grep -E '^\s*bloom_level:' "$yaml" | head -1 | sed 's/^.*bloom_level:[[:space:]]*//' | tr -d '"' | tr -d "'" | xargs)
         BLOOM_NUM=$(echo "$BLOOM" | sed 's/[^0-9]//g')
         [ -n "$BLOOM_NUM" ] || continue
         [ "$BLOOM_NUM" -ge 4 ] 2>/dev/null || continue
-        TASK_ID=$(python3 -c "
-import sys, yaml as y
-try:
-    d = y.safe_load(open('$yaml'))
-    t = d.get('task', d) if d else {}
-    print(t.get('task_id', ''))
-except: pass
-" 2>/dev/null || true)
+        TASK_ID=$(grep -E '^\s*task_id:' "$yaml" | head -1 | sed 's/^.*task_id:[[:space:]]*//' | tr -d '"' | tr -d "'" | xargs)
         [ -n "$TASK_ID" ] && [ "$TASK_ID" != "null" ] || continue
         QC_FILE="$SCRIPT_DIR/queue/reports/${TASK_ID}_qc.yaml"
         if [ ! -f "$QC_FILE" ]; then

--- a/scripts/stop_hook_inbox.sh
+++ b/scripts/stop_hook_inbox.sh
@@ -178,7 +178,7 @@ try:
     print(t.get('bloom_level', ''))
 except: pass
 " 2>/dev/null || true)
-        BLOOM_NUM=$(echo "$BLOOM" | grep -oP '\d+' || true)
+        BLOOM_NUM=$(echo "$BLOOM" | sed 's/[^0-9]//g')
         [ -n "$BLOOM_NUM" ] || continue
         [ "$BLOOM_NUM" -ge 4 ] 2>/dev/null || continue
         TASK_ID=$(python3 -c "

--- a/scripts/stop_hook_inbox.sh
+++ b/scripts/stop_hook_inbox.sh
@@ -154,6 +154,59 @@ print(json.dumps({'decision': 'block', 'reason': reason}, ensure_ascii=False))
 " 2>/dev/null || echo "{\"decision\":\"block\",\"reason\":\"日報未追記: ${STALE_CMD_DAILY}完了後にlogs/daily/${TODAY}.mdが更新されていません。\"}"
         exit 0
     fi
+
+    # ─── Karo: bloom L4以上タスクのQCゲートチェック ───
+    # bloom_level L4以上のサブタスクがdoneになっているが、軍師QCレポートが
+    # 存在しない（またはreviewed_by: gunshiがない）場合にブロックする。
+    QC_MISSING=""
+    for yaml in "$SCRIPT_DIR/queue/tasks/ashigaru"*.yaml; do
+        [ -f "$yaml" ] || continue
+        STATUS=$(python3 -c "
+import sys, yaml as y
+try:
+    d = y.safe_load(open('$yaml'))
+    t = d.get('task', d) if d else {}
+    print(t.get('status', ''))
+except: pass
+" 2>/dev/null || true)
+        [ "$STATUS" = "done" ] || continue
+        BLOOM=$(python3 -c "
+import sys, yaml as y
+try:
+    d = y.safe_load(open('$yaml'))
+    t = d.get('task', d) if d else {}
+    print(t.get('bloom_level', ''))
+except: pass
+" 2>/dev/null || true)
+        BLOOM_NUM=$(echo "$BLOOM" | grep -oP '\d+' || true)
+        [ -n "$BLOOM_NUM" ] || continue
+        [ "$BLOOM_NUM" -ge 4 ] 2>/dev/null || continue
+        TASK_ID=$(python3 -c "
+import sys, yaml as y
+try:
+    d = y.safe_load(open('$yaml'))
+    t = d.get('task', d) if d else {}
+    print(t.get('task_id', ''))
+except: pass
+" 2>/dev/null || true)
+        [ -n "$TASK_ID" ] && [ "$TASK_ID" != "null" ] || continue
+        QC_FILE="$SCRIPT_DIR/queue/reports/${TASK_ID}_qc.yaml"
+        if [ ! -f "$QC_FILE" ]; then
+            QC_MISSING="${TASK_ID} (bloom: ${BLOOM}) QCレポートなし"
+            break
+        elif ! grep -q "reviewed_by: gunshi" "$QC_FILE"; then
+            QC_MISSING="${TASK_ID} (bloom: ${BLOOM}) 軍師レビューなし"
+            break
+        fi
+    done
+    if [ -n "$QC_MISSING" ]; then
+        python3 -c "
+import json
+reason = 'QCゲートブロック: ${QC_MISSING}。queue/reports/{task_id}_qc.yaml（reviewed_by: gunshi）が必要です。軍師QCを依頼してください（karo.md QCゲートルール）。'
+print(json.dumps({'decision': 'block', 'reason': reason}, ensure_ascii=False))
+" 2>/dev/null || echo "{\"decision\":\"block\",\"reason\":\"QCゲートブロック: ${QC_MISSING}。軍師QCレポートが必要です。\"}"
+        exit 0
+    fi
 fi
 
 # ─── Check inbox for unread messages ───

--- a/tests/unit/test_stop_hook.bats
+++ b/tests/unit/test_stop_hook.bats
@@ -424,3 +424,193 @@ YAML
     echo "$output" | grep -q '"block"'
     ! echo "$output" | grep -q '日報未追記'
 }
+
+# ─── T-HOOK-021〜026: bloom L4 QCゲートチェック ───
+
+@test "T-HOOK-021: karo + bloom L4 done task without QC report → block" {
+    # karo が bloom_level L4 のタスクをdoneにしたがQCレポートなし → ブロック
+    mkdir -p "$TEST_TMP/queue/inbox" "$TEST_TMP/queue/tasks" "$TEST_TMP/queue/reports"
+    # dashboard と daily log は最新にしてそれらのブロックを回避
+    cat > "$TEST_TMP/dashboard.md" << 'MD'
+# 戦況報告
+最終更新: now
+MD
+    cat > "$TEST_TMP/queue/inbox/karo.yaml" << 'YAML'
+messages:
+  - id: msg_001
+    from: shogun
+    type: cmd_new
+    content: "テスト"
+    read: true
+YAML
+    cat > "$TEST_TMP/queue/tasks/ashigaru1.yaml" << 'YAML'
+task:
+  task_id: subtask_test_l4
+  bloom_level: L4
+  status: done
+YAML
+    # QCレポートなし（queue/reports/ は空）
+    __STOP_HOOK_SCRIPT_DIR="$TEST_TMP" \
+    __STOP_HOOK_AGENT_ID="karo" \
+    run bash "$HOOK_SCRIPT" <<< '{"stop_hook_active": false, "last_assistant_message": ""}'
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q '"decision"'
+    echo "$output" | grep -q '"block"'
+    echo "$output" | grep -q 'QC'
+}
+
+@test "T-HOOK-022: karo + bloom L4 done task with gunshi QC report → no QC block" {
+    # karo が bloom_level L4 のタスクをdoneにし、QCレポートあり(reviewed_by: gunshi) → QCブロック不発
+    mkdir -p "$TEST_TMP/queue/inbox" "$TEST_TMP/queue/tasks" "$TEST_TMP/queue/reports"
+    cat > "$TEST_TMP/dashboard.md" << 'MD'
+# 戦況報告
+最終更新: now
+MD
+    cat > "$TEST_TMP/queue/tasks/ashigaru1.yaml" << 'YAML'
+task:
+  task_id: subtask_test_l4b
+  bloom_level: L4
+  status: done
+YAML
+    # QCレポートあり（reviewed_by: gunshi）
+    cat > "$TEST_TMP/queue/reports/subtask_test_l4b_qc.yaml" << 'YAML'
+task_id: subtask_test_l4b
+reviewed_by: gunshi
+result: pass
+YAML
+    # 未読inbox（高速終了用 — QCブロックでないことを確認）
+    cat > "$TEST_TMP/queue/inbox/karo.yaml" << 'YAML'
+messages:
+  - id: msg_001
+    from: shogun
+    type: cmd_new
+    content: "次のタスク"
+    read: false
+YAML
+    __STOP_HOOK_SCRIPT_DIR="$TEST_TMP" \
+    __STOP_HOOK_AGENT_ID="karo" \
+    run bash "$HOOK_SCRIPT" <<< '{"stop_hook_active": false, "last_assistant_message": ""}'
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q '"block"'
+    ! echo "$output" | grep -q 'QC'
+}
+
+@test "T-HOOK-023: karo + bloom L3 done task without QC report → no QC block" {
+    # bloom_level L3 はQCゲート対象外 → ブロック不発
+    mkdir -p "$TEST_TMP/queue/inbox" "$TEST_TMP/queue/tasks" "$TEST_TMP/queue/reports"
+    cat > "$TEST_TMP/dashboard.md" << 'MD'
+# 戦況報告
+最終更新: now
+MD
+    cat > "$TEST_TMP/queue/tasks/ashigaru1.yaml" << 'YAML'
+task:
+  task_id: subtask_test_l3
+  bloom_level: L3
+  status: done
+YAML
+    # QCレポートなし
+    cat > "$TEST_TMP/queue/inbox/karo.yaml" << 'YAML'
+messages:
+  - id: msg_001
+    from: shogun
+    type: cmd_new
+    content: "次のタスク"
+    read: false
+YAML
+    __STOP_HOOK_SCRIPT_DIR="$TEST_TMP" \
+    __STOP_HOOK_AGENT_ID="karo" \
+    run bash "$HOOK_SCRIPT" <<< '{"stop_hook_active": false, "last_assistant_message": ""}'
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q '"block"'
+    ! echo "$output" | grep -q 'QC'
+}
+
+@test "T-HOOK-024: karo + bloom L4 done task QC report without gunshi → block" {
+    # QCレポートはあるがreviewed_by: gunshiなし → ブロック
+    mkdir -p "$TEST_TMP/queue/inbox" "$TEST_TMP/queue/tasks" "$TEST_TMP/queue/reports"
+    cat > "$TEST_TMP/dashboard.md" << 'MD'
+# 戦況報告
+最終更新: now
+MD
+    cat > "$TEST_TMP/queue/inbox/karo.yaml" << 'YAML'
+messages:
+  - id: msg_001
+    from: shogun
+    type: cmd_new
+    content: "テスト"
+    read: true
+YAML
+    cat > "$TEST_TMP/queue/tasks/ashigaru1.yaml" << 'YAML'
+task:
+  task_id: subtask_test_l4c
+  bloom_level: L4
+  status: done
+YAML
+    # QCレポートあり、しかし reviewed_by: ashigaru（gunshiではない）
+    cat > "$TEST_TMP/queue/reports/subtask_test_l4c_qc.yaml" << 'YAML'
+task_id: subtask_test_l4c
+reviewed_by: ashigaru1
+result: pass
+YAML
+    __STOP_HOOK_SCRIPT_DIR="$TEST_TMP" \
+    __STOP_HOOK_AGENT_ID="karo" \
+    run bash "$HOOK_SCRIPT" <<< '{"stop_hook_active": false, "last_assistant_message": ""}'
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q '"decision"'
+    echo "$output" | grep -q '"block"'
+    echo "$output" | grep -q 'QC'
+}
+
+@test "T-HOOK-025: karo + bloom L4 in_progress task → no QC check" {
+    # in_progress（未完了）のタスクはQCゲート対象外 → ブロック不発
+    mkdir -p "$TEST_TMP/queue/inbox" "$TEST_TMP/queue/tasks" "$TEST_TMP/queue/reports"
+    cat > "$TEST_TMP/dashboard.md" << 'MD'
+# 戦況報告
+最終更新: now
+MD
+    cat > "$TEST_TMP/queue/tasks/ashigaru1.yaml" << 'YAML'
+task:
+  task_id: subtask_test_l4d
+  bloom_level: L4
+  status: in_progress
+YAML
+    # QCレポートなし
+    cat > "$TEST_TMP/queue/inbox/karo.yaml" << 'YAML'
+messages:
+  - id: msg_001
+    from: shogun
+    type: cmd_new
+    content: "次のタスク"
+    read: false
+YAML
+    __STOP_HOOK_SCRIPT_DIR="$TEST_TMP" \
+    __STOP_HOOK_AGENT_ID="karo" \
+    run bash "$HOOK_SCRIPT" <<< '{"stop_hook_active": false, "last_assistant_message": ""}'
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q '"block"'
+    ! echo "$output" | grep -q 'QC'
+}
+
+@test "T-HOOK-026: non-karo agent bloom L4 task → no QC check" {
+    # karo以外のエージェント（ashigaru）はQCゲート対象外 → ブロック不発
+    mkdir -p "$TEST_TMP/queue/inbox" "$TEST_TMP/queue/tasks" "$TEST_TMP/queue/reports"
+    cat > "$TEST_TMP/queue/tasks/ashigaru1.yaml" << 'YAML'
+task:
+  task_id: subtask_test_l4e
+  bloom_level: L4
+  status: done
+YAML
+    # QCレポートなし
+    cat > "$TEST_TMP/queue/inbox/ashigaru1.yaml" << 'YAML'
+messages:
+  - id: msg_001
+    from: karo
+    type: task_assigned
+    content: "次のタスク"
+    read: false
+YAML
+    run_hook '{"stop_hook_active": false, "last_assistant_message": ""}' "ashigaru1"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q '"block"'
+    ! echo "$output" | grep -q 'QC'
+}


### PR DESCRIPTION
## 概要

stop_hook_inbox.sh に bloom_level L4以上のサブタスクが `done` になった際、
軍師（gunshi）のQCレポート（`queue/reports/{task_id}_qc.yaml`）が存在しない場合に
家老（karo）の stop を block するゲートを追加。

## 変更内容

- `scripts/stop_hook_inbox.sh` — bloom L4+ QCゲートチェック追加（L160〜210）
- `tests/unit/test_stop_hook.bats` — T-HOOK-021〜026 追加（6件）
- `instructions/karo.md` — QCゲートルール説明を追加

## テスト結果

```
1..26
ok 1〜26 全件 PASS（SKIP 0件）
```

## QCゲート仕様

| 条件 | 動作 |
|------|------|
| karo + bloom L4+ done + QCレポートなし | block |
| karo + bloom L4+ done + reviewed_by: gunshi あり | 通過 |
| karo + bloom L4+ done + reviewed_by: gunshi なし | block |
| karo + bloom L3 以下 | チェックなし |
| karo + in_progress | チェックなし |
| karo 以外のエージェント | チェックなし |

## チェックリスト

- [x] テスト全件 PASS（26/26、SKIP 0）
- [x] 自動マージ禁止 — 殿の確認後にマージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)