### PR TITLE
✨ 家老コンテキスト枯渇防止: cmd完了即/clearルール導入 (close #68)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,7 @@ System manages ALL white-collar work, not just self-improvement. Project folders
    b. `bash scripts/ntfy.sh "✅ cmd_{id} 完了 — {summary}"` で将軍に完了通知
    c. タスクYAMLの `status` を `done` に更新
 2. **Session Start/Recovery時**: 必ず `instructions/karo.md` を読み込む（Step 4をスキップしない）。summaryやcompactionの存在を問わず必須。スキップした場合、dashboard更新・ntfy送信を全タスクでスキップする事故が起きる（2026-03-28実例: cmd_060〜064で5タスク連続スキップ）。
+3. **cmd完了即/clear**: cmd完了→Step 12-13全完了後、/clearを実行してコンテキストをリセットする。/clear前に `queue/tasks/karo.yaml` の `handoff_note` に引き継ぎ情報を記載する。compactionでルールが揮発するよりも、制御された/clearの方が安全である。
 
 # Test Rules (all agents)
 

--- a/instructions/karo.md
+++ b/instructions/karo.md
@@ -872,6 +872,41 @@ When conditions met → execute self-/clear:
 
 **Why this helps**: Prevents the 4% context exhaustion that halted karo during cmd_166 (2,754 article production).
 
+### cmd完了即/clear原則
+
+After completing a cmd (Step 12-13 fully done), evaluate /clear EVERY time.
+
+#### /clear実行条件（ALL満たす場合に実行）
+
+1. **Step 12-13全完了**: dashboard更新済み・ntfy送信済み・日報追記済み
+2. **inbox未読ゼロ**: `queue/inbox/karo.yaml` に `read: false` が0件
+3. **足軽idle or 30分超経過**: 全足軽がidle、または最後のdispatchから30分以上経過
+
+#### /clear前の必須手順
+
+```
+1. bash scripts/slim_yaml.sh karo   # YAML圧縮
+2. queue/tasks/karo.yaml の handoff_note に引き継ぎ情報を記載（5行以内）
+3. /clear 実行
+```
+
+#### /clear禁止タイミング
+
+| 状況 | 理由 |
+|------|------|
+| Step 12-13の途中（dashboard未更新 or ntfy未送信） | ルールが揮発する |
+| dispatch直後で報告待ち（30分未満） | 未処理報告が来る可能性 |
+
+#### handoff_note 記載例
+
+```yaml
+handoff_note: |
+  cmd_117〜121は同一PR#6の作業。マージ待ち。
+  cmd_122はQC PASS済み。PR#67マージ待ち。
+```
+
+Session Start時に `queue/tasks/karo.yaml` を読む際に自動的に引き継がれる。
+
 ## Redo Protocol (Task Correction)
 
 When an ashigaru's output is unsatisfactory and needs to be redone.


### PR DESCRIPTION
## Summary

- `CLAUDE.md`: Karo Mandatory Rulesに「cmd完了即/clear」ルール（3項目目）を追加
- `instructions/karo.md`: 「cmd完了即/clear原則」セクションを新設（/clear条件・前必須手順・禁止タイミング・handoff_note例）
- `queue/tasks/karo.yaml`: `handoff_note`フィールドを追加（gitignore対象、ローカルのみ有効）

## 背景

家老が複数cmdを1セッションで処理するとコンテキストが枯渇し（113%超過実例あり）、compaction後にdashboard更新・ntfy送信ルールが揮発する問題を修正する。制御された/clearの方がcompactionよりも安全。

## Test plan

- [x] 全354ユニットテストPASS（SKIPなし）
- [x] ShellCheck通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)