### PR TITLE
🔄 upstream v4.5.0 sync (merge)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+github: [yohey-w]
+custom:
+  - "https://zenn.dev/shio_shoppaize"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,7 +19,7 @@ files:
   tasks: "queue/tasks/ashigaru{N}.yaml" # Karo → Ashigaru assignments (per-ashigaru)
   gunshi_task: queue/tasks/gunshi.yaml  # Karo → Gunshi strategic assignments
   pending_tasks: queue/tasks/pending.yaml # Karo管理の保留タスク（blocked未割当）
-  reports: "queue/reports/ashigaru{N}_report.yaml" # Ashigaru → Karo reports
+  reports: "queue/reports/ashigaru{N}_report.yaml" # Ashigaru → Gunshi reports
   gunshi_report: queue/reports/gunshi_report.yaml  # Gunshi → Karo strategic reports
   dashboard: dashboard.md              # Human-readable summary (secondary data)
   daily_log: "logs/daily/YYYY-MM-DD.md" # Karo appends cmd summary on completion. Shogun reads for daily reports.
@@ -37,6 +37,7 @@ task_status_transitions:
   - "assigned → failed (ashigaru fails)"
   - "pending_blocked（家老キュー保留）→ assigned（依存完了後に割当）"
   - "RULE: Ashigaru updates OWN yaml only. Never touch other ashigaru's yaml."
+  - "RULE: On /clear recovery, if assigned=done → DO NOT re-send report. Wait idle. (prevents duplicate report loop)"
   - "RULE: blocked状態タスクを足軽へ事前割当しない。前提完了までpending_tasksで保留。"
 
 # Status definitions are authoritative in:
@@ -81,10 +82,11 @@ Lightweight recovery using only copilot-instructions.md (auto-loaded). Do NOT re
 ```
 Step 1: tmux display-message -t "$TMUX_PANE" -p '#{@agent_id}' → ashigaru{N} or gunshi
 Step 2: (gunshi only) mcp__memory__read_graph (skip on failure). Ashigaru skip — task YAML is sufficient.
-Step 3: Read queue/tasks/{your_id}.yaml → assigned=work, idle=wait
+Step 3: Read queue/tasks/{your_id}.yaml →
+        assigned=work (execute task), idle=wait, done=wait (DO NOT re-report)
 Step 4: If task has "project:" field → read context/{project}.md
         If task has "target_path:" → read that file
-Step 5: Start work
+Step 5: Start work (only if assigned=work)
 ```
 
 **CRITICAL**: Steps 1-3を完了するまでinbox処理するな。`inboxN` nudgeが先に届いても無視し、自己識別を必ず先に終わらせよ。
@@ -119,8 +121,8 @@ Examples:
 # Shogun → Karo
 bash scripts/inbox_write.sh karo "cmd_048を書いた。実行せよ。" cmd_new shogun
 
-# Ashigaru → Karo
-bash scripts/inbox_write.sh karo "足軽5号、任務完了。報告YAML確認されたし。" report_received ashigaru5
+# Ashigaru → Gunshi
+bash scripts/inbox_write.sh gunshi "足軽5号、任務完了。品質チェックを仰ぎたし。" report_received ashigaru5
 
 # Karo → Ashigaru
 bash scripts/inbox_write.sh ashigaru3 "タスクYAMLを読んで作業開始せよ。" task_assigned karo

--- a/.gitignore
+++ b/.gitignore
@@ -183,6 +183,7 @@ tests/specs/osato_lms_*
 
 # CI/CD
 !.github/
+!.github/FUNDING.yml
 !.github/workflows/
 !.github/workflows/*.yml
 

--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@
 !scripts/agent_status.sh
 !scripts/ratelimit_check.sh
 !scripts/switch_cli.sh
+!scripts/dashboard-viewer.py
 
 
 # SayTask (sample template only, not actual data)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ files:
   tasks: "queue/tasks/ashigaru{N}.yaml" # Karo → Ashigaru assignments (per-ashigaru)
   gunshi_task: queue/tasks/gunshi.yaml  # Karo → Gunshi strategic assignments
   pending_tasks: queue/tasks/pending.yaml # Karo管理の保留タスク（blocked未割当）
-  reports: "queue/reports/ashigaru{N}_report.yaml" # Ashigaru → Karo reports
+  reports: "queue/reports/ashigaru{N}_report.yaml" # Ashigaru → Gunshi reports
   gunshi_report: queue/reports/gunshi_report.yaml  # Gunshi → Karo strategic reports
   dashboard: dashboard.md              # Human-readable summary (secondary data)
   daily_log: "logs/daily/YYYY-MM-DD.md" # Karo appends cmd summary on completion. Shogun reads for daily reports.
@@ -37,6 +37,7 @@ task_status_transitions:
   - "assigned → failed (ashigaru fails)"
   - "pending_blocked（家老キュー保留）→ assigned（依存完了後に割当）"
   - "RULE: Ashigaru updates OWN yaml only. Never touch other ashigaru's yaml."
+  - "RULE: On /clear recovery, if assigned=done → DO NOT re-send report. Wait idle. (prevents duplicate report loop)"
   - "RULE: blocked状態タスクを足軽へ事前割当しない。前提完了までpending_tasksで保留。"
 
 # Status definitions are authoritative in:
@@ -81,10 +82,11 @@ Lightweight recovery using only AGENTS.md (auto-loaded). Do NOT read instruction
 ```
 Step 1: tmux display-message -t "$TMUX_PANE" -p '#{@agent_id}' → ashigaru{N} or gunshi
 Step 2: (gunshi only) mcp__memory__read_graph (skip on failure). Ashigaru skip — task YAML is sufficient.
-Step 3: Read queue/tasks/{your_id}.yaml → assigned=work, idle=wait
+Step 3: Read queue/tasks/{your_id}.yaml →
+        assigned=work (execute task), idle=wait, done=wait (DO NOT re-report)
 Step 4: If task has "project:" field → read context/{project}.md
         If task has "target_path:" → read that file
-Step 5: Start work
+Step 5: Start work (only if assigned=work)
 ```
 
 **CRITICAL**: Steps 1-3を完了するまでinbox処理するな。`inboxN` nudgeが先に届いても無視し、自己識別を必ず先に終わらせよ。
@@ -119,8 +121,8 @@ Examples:
 # Shogun → Karo
 bash scripts/inbox_write.sh karo "cmd_048を書いた。実行せよ。" cmd_new shogun
 
-# Ashigaru → Karo
-bash scripts/inbox_write.sh karo "足軽5号、任務完了。報告YAML確認されたし。" report_received ashigaru5
+# Ashigaru → Gunshi
+bash scripts/inbox_write.sh gunshi "足軽5号、任務完了。品質チェックを仰ぎたし。" report_received ashigaru5
 
 # Karo → Ashigaru
 bash scripts/inbox_write.sh ashigaru3 "タスクYAMLを読んで作業開始せよ。" task_assigned karo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.4.2] - 2026-04-10
+
+### Added
+- `first_setup.sh`: auto-install OSS skills to `~/.claude/skills/` on setup (skips existing, idempotent)
+
 ## [4.4.1] - 2026-03-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.5.0] - 2026-04-19
+
+### Added
+- `scripts/dashboard-viewer.py`: live Markdown viewer for `dashboard.md` via `dash` command (PR #122)
+- `first_setup.sh`: auto-register `dash()` function to `.bashrc` on setup
+- GitHub Sponsors section to README and README_ja
+
+### Fixed
+- `scripts/inbox_write.sh`: self-send guard — prevent agents from messaging themselves (PR #116)
+- README quick start: missing `source ~/.bashrc` and `claude --dangerously-skip-permissions` steps (Issue #120)
+
+### Changed
+- `tests/test_inbox_write.bats`: updated for mandatory `type`/`from` arguments
+
 ## [4.4.2] - 2026-04-10
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ task_status_transitions:
   - "assigned → failed (ashigaru fails)"
   - "pending_blocked（家老キュー保留）→ assigned（依存完了後に割当）"
   - "RULE: Ashigaru updates OWN yaml only. Never touch other ashigaru's yaml."
+  - "RULE: On /clear recovery, if assigned=done → DO NOT re-send report. Wait idle. (prevents duplicate report loop)"
   - "RULE: blocked状態タスクを足軽へ事前割当しない。前提完了までpending_tasksで保留。"
 
 # Status definitions are authoritative in:
@@ -81,10 +82,11 @@ Lightweight recovery using only CLAUDE.md (auto-loaded). Do NOT read instruction
 ```
 Step 1: tmux display-message -t "$TMUX_PANE" -p '#{@agent_id}' → ashigaru{N} or gunshi
 Step 2: (gunshi only) mcp__memory__read_graph (skip on failure). Ashigaru skip — task YAML is sufficient.
-Step 3: Read queue/tasks/{your_id}.yaml → assigned=work, idle=wait
+Step 3: Read queue/tasks/{your_id}.yaml →
+        assigned=work (execute task), idle=wait, done=wait (DO NOT re-report)
 Step 4: If task has "project:" field → read context/{project}.md
         If task has "target_path:" → read that file
-Step 5: Start work
+Step 5: Start work (only if assigned=work)
 ```
 
 **CRITICAL**: Steps 1-3を完了するまでinbox処理するな。`inboxN` nudgeが先に届いても無視し、自己識別を必ず先に終わらせよ。

--- a/README.md
+++ b/README.md
@@ -1809,6 +1809,22 @@ Even if you're not comfortable with keyboard shortcuts, you can switch, scroll, 
 
 ---
 
+## Sponsors
+
+This project is funded by sponsors. Your support keeps it free and actively maintained.
+
+<a href="https://github.com/sponsors/yohey-w">
+  <img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-ea4aaa?style=for-the-badge&logo=github-sponsors" alt="Sponsor">
+</a>
+
+| Tier | Perks |
+|------|-------|
+| ☕ $5/mo | Name in sponsors section |
+| 🏯 $25/mo | Early access to new releases |
+| ⚔️ $100/mo | Priority issue/PR response (48h) |
+| 🎖️ $500/mo | Monthly 1:1 consultation |
+| 🏛️ $1,000/mo | Logo in README + quarterly strategy session |
+
 ## Contributing
 
 Issues and pull requests are welcome.
@@ -1832,5 +1848,7 @@ Based on [Claude-Code-Communication](https://github.com/Akira-Papa/Claude-Code-C
 **One command. Eight agents. Zero coordination cost.**
 
 ⭐ Star this repo if you find it useful — it helps others discover it.
+
+💖 [Sponsor this project](https://github.com/sponsors/yohey-w) to keep it free.
 
 </div>

--- a/README.md
+++ b/README.md
@@ -37,9 +37,13 @@ Run 10 AI coding agents in parallel — **Claude Code, OpenAI Codex, GitHub Copi
 ```bash
 git clone https://github.com/yohey-w/multi-agent-shogun
 cd multi-agent-shogun
-bash first_setup.sh          # one-time setup: config, dependencies, MCP
-bash shutsujin_departure.sh  # launch all agents
+bash first_setup.sh                        # one-time setup: config, dependencies, MCP
+source ~/.bashrc                           # reload PATH
+claude --dangerously-skip-permissions      # first run only: OAuth + accept Bypass Permissions → /exit
+bash shutsujin_departure.sh                # launch all agents
 ```
+
+> For full install steps (incl. Windows) and the first-30-minutes walkthrough, see [🚀 Quick Start](#-quick-start) and the basic usage section below.
 
 Type a command in the Shogun pane:
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -1762,6 +1762,22 @@ tmux respawn-pane -t shogun:0.0 -k 'claude --model opus --dangerously-skip-permi
 
 ---
 
+## スポンサー
+
+このプロジェクトはスポンサーによって支えられています。
+
+<a href="https://github.com/sponsors/yohey-w">
+  <img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-ea4aaa?style=for-the-badge&logo=github-sponsors" alt="Sponsor">
+</a>
+
+| Tier | 特典 |
+|------|------|
+| ☕ $5/月 | スポンサーセクションに名前掲載 |
+| 🏯 $25/月 | 新リリースへの早期アクセス |
+| ⚔️ $100/月 | Issue/PRの優先対応（48h以内） |
+| 🎖️ $500/月 | 月1回の1on1コンサルテーション |
+| 🏛️ $1,000/月 | READMEにロゴ掲載 + 四半期戦略コンサル |
+
 ## コントリビューション
 
 Issue、Pull Requestを歓迎します。
@@ -1787,5 +1803,7 @@ MIT License - 詳細は [LICENSE](LICENSE) を参照。
 **コマンド1つ。エージェント8体。連携コストゼロ。**
 
 ⭐ 役に立ったらスターをお願いします — 他の人にも見つけてもらえます。
+
+💖 [このプロジェクトをスポンサーする](https://github.com/sponsors/yohey-w)
 
 </div>

--- a/README_ja.md
+++ b/README_ja.md
@@ -37,9 +37,13 @@
 ```bash
 git clone https://github.com/yohey-w/multi-agent-shogun
 cd multi-agent-shogun
-bash first_setup.sh          # 初回セットアップ: 設定・依存関係・MCP
-bash shutsujin_departure.sh  # 全エージェント起動
+bash first_setup.sh                        # 初回セットアップ: 設定・依存関係・MCP
+source ~/.bashrc                           # PATH反映
+claude --dangerously-skip-permissions      # 初回のみ: OAuth認証 + Bypass承認 → /exit で退出
+bash shutsujin_departure.sh                # 全エージェント起動
 ```
+
+> 詳しいインストール手順（Windows含む）と「最初の30分の歩き方」は下記 [🚀 クイックスタート](#-クイックスタート) と [📖 基本的な使い方](#-基本的な使い方) を参照。
 
 将軍ペインに命令を入力：
 

--- a/agents/default/system.md
+++ b/agents/default/system.md
@@ -19,7 +19,7 @@ files:
   tasks: "queue/tasks/ashigaru{N}.yaml" # Karo → Ashigaru assignments (per-ashigaru)
   gunshi_task: queue/tasks/gunshi.yaml  # Karo → Gunshi strategic assignments
   pending_tasks: queue/tasks/pending.yaml # Karo管理の保留タスク（blocked未割当）
-  reports: "queue/reports/ashigaru{N}_report.yaml" # Ashigaru → Karo reports
+  reports: "queue/reports/ashigaru{N}_report.yaml" # Ashigaru → Gunshi reports
   gunshi_report: queue/reports/gunshi_report.yaml  # Gunshi → Karo strategic reports
   dashboard: dashboard.md              # Human-readable summary (secondary data)
   daily_log: "logs/daily/YYYY-MM-DD.md" # Karo appends cmd summary on completion. Shogun reads for daily reports.
@@ -37,6 +37,7 @@ task_status_transitions:
   - "assigned → failed (ashigaru fails)"
   - "pending_blocked（家老キュー保留）→ assigned（依存完了後に割当）"
   - "RULE: Ashigaru updates OWN yaml only. Never touch other ashigaru's yaml."
+  - "RULE: On /clear recovery, if assigned=done → DO NOT re-send report. Wait idle. (prevents duplicate report loop)"
   - "RULE: blocked状態タスクを足軽へ事前割当しない。前提完了までpending_tasksで保留。"
 
 # Status definitions are authoritative in:
@@ -81,10 +82,11 @@ Lightweight recovery using only agents/default/system.md (auto-loaded). Do NOT r
 ```
 Step 1: tmux display-message -t "$TMUX_PANE" -p '#{@agent_id}' → ashigaru{N} or gunshi
 Step 2: (gunshi only) mcp__memory__read_graph (skip on failure). Ashigaru skip — task YAML is sufficient.
-Step 3: Read queue/tasks/{your_id}.yaml → assigned=work, idle=wait
+Step 3: Read queue/tasks/{your_id}.yaml →
+        assigned=work (execute task), idle=wait, done=wait (DO NOT re-report)
 Step 4: If task has "project:" field → read context/{project}.md
         If task has "target_path:" → read that file
-Step 5: Start work
+Step 5: Start work (only if assigned=work)
 ```
 
 **CRITICAL**: Steps 1-3を完了するまでinbox処理するな。`inboxN` nudgeが先に届いても無視し、自己識別を必ず先に終わらせよ。
@@ -119,8 +121,8 @@ Examples:
 # Shogun → Karo
 bash scripts/inbox_write.sh karo "cmd_048を書いた。実行せよ。" cmd_new shogun
 
-# Ashigaru → Karo
-bash scripts/inbox_write.sh karo "足軽5号、任務完了。報告YAML確認されたし。" report_received ashigaru5
+# Ashigaru → Gunshi
+bash scripts/inbox_write.sh gunshi "足軽5号、任務完了。品質チェックを仰ぎたし。" report_received ashigaru5
 
 # Karo → Ashigaru
 bash scripts/inbox_write.sh ashigaru3 "タスクYAMLを読んで作業開始せよ。" task_assigned karo

--- a/first_setup.sh
+++ b/first_setup.sh
@@ -573,6 +573,45 @@ fi
 RESULTS+=("ディレクトリ構造: OK (作成:$CREATED_COUNT, 既存:$EXISTED_COUNT)")
 
 # ============================================================
+# STEP 6.5: OSSスキルインストール
+# ============================================================
+log_step "STEP 6.5: OSSスキルインストール"
+
+CLAUDE_SKILLS_DIR="$HOME/.claude/skills"
+mkdir -p "$CLAUDE_SKILLS_DIR"
+
+INSTALLED_SKILLS=0
+SKIPPED_SKILLS=0
+FOUND_SKILLS=0
+
+shopt -s nullglob
+for skill_dir in "$SCRIPT_DIR/skills"/*/; do
+    [ -d "$skill_dir" ] || continue
+
+    FOUND_SKILLS=$((FOUND_SKILLS + 1))
+    skill_name=$(basename "$skill_dir")
+    target="$CLAUDE_SKILLS_DIR/$skill_name"
+
+    if [ -d "$target" ]; then
+        log_info "スキル $skill_name は既に存在します（スキップ）"
+        SKIPPED_SKILLS=$((SKIPPED_SKILLS + 1))
+    else
+        cp -r "$skill_dir" "$target"
+        log_success "スキルをインストールしました: $skill_name"
+        INSTALLED_SKILLS=$((INSTALLED_SKILLS + 1))
+    fi
+done
+shopt -u nullglob
+
+if [ "$FOUND_SKILLS" -eq 0 ]; then
+    log_warn "インストール可能なスキルが見つかりませんでした"
+    RESULTS+=("OSSスキル: スキップ (skills/ 未検出)")
+else
+    log_info "/shogun-model-switch などのスキルが使用可能になりました"
+    RESULTS+=("OSSスキル: OK (新規:$INSTALLED_SKILLS, 既存:$SKIPPED_SKILLS)")
+fi
+
+# ============================================================
 # STEP 7: 設定ファイル初期化
 # ============================================================
 log_step "STEP 7: 設定ファイル確認"

--- a/first_setup.sh
+++ b/first_setup.sh
@@ -754,6 +754,7 @@ BASHRC_FILE="$HOME/.bashrc"
 # - 本体セッション (shogun/multiagent) は絶対に消えない
 CSS_FUNC='css() { local s="shogun-$$"; local cols=$(tput cols 2>/dev/null || echo 80); tmux new-session -d -t shogun -s "$s" 2>/dev/null && tmux set-option -t "$s" destroy-unattached on 2>/dev/null; if [ "$cols" -lt 80 ]; then tmux new-window -t "$s" -n mobile 2>/dev/null; tmux attach-session -t "$s:mobile" 2>/dev/null || tmux attach-session -t shogun; else tmux attach-session -t "$s" 2>/dev/null || tmux attach-session -t shogun; fi; }'
 CSM_FUNC='csm() { local s="multi-$$"; local cols=$(tput cols 2>/dev/null || echo 80); tmux new-session -d -t multiagent -s "$s" 2>/dev/null && tmux set-option -t "$s" destroy-unattached on 2>/dev/null; if [ "$cols" -lt 80 ]; then tmux new-window -t "$s" -n mobile 2>/dev/null; tmux attach-session -t "$s:mobile" 2>/dev/null || tmux attach-session -t multiagent; else tmux attach-session -t "$s" 2>/dev/null || tmux attach-session -t multiagent; fi; }'
+DASH_FUNC="dash() { python3 \"$SCRIPT_DIR/scripts/dashboard-viewer.py\" \"\$@\"; }"
 
 ALIAS_ADDED=false
 
@@ -794,6 +795,18 @@ if [ -f "$BASHRC_FILE" ]; then
         sed -i '/^csm()/d' "$BASHRC_FILE"
         echo "$CSM_FUNC" >> "$BASHRC_FILE"
         log_info "csm 関数を更新しました"
+        ALIAS_ADDED=true
+    fi
+
+    # dash 関数
+    if ! grep -q "^dash()" "$BASHRC_FILE" 2>/dev/null; then
+        echo "$DASH_FUNC" >> "$BASHRC_FILE"
+        log_info "dash 関数を追加しました（ダッシュボードビューア）"
+        ALIAS_ADDED=true
+    else
+        sed -i '/^dash()/d' "$BASHRC_FILE"
+        echo "$DASH_FUNC" >> "$BASHRC_FILE"
+        log_info "dash 関数を更新しました"
         ALIAS_ADDED=true
     fi
 else

--- a/instructions/generated/ashigaru.md
+++ b/instructions/generated/ashigaru.md
@@ -67,7 +67,7 @@ Act without waiting for Karo's instruction:
 1. Self-review deliverables (re-read your output)
 2. **Purpose validation**: Read `parent_cmd` in `queue/shogun_to_karo.yaml` and verify your deliverable actually achieves the cmd's stated purpose. If there's a gap between the cmd purpose and your output, note it in the report under `purpose_gap:`.
 3. Write report YAML
-4. Notify Karo via inbox_write
+4. Notify Gunshi via inbox_write (NOT Karo directly)
 5. **Check own inbox** (MANDATORY): Read `queue/inbox/ashigaru{N}.yaml`, process any `read: false` entries. This catches redo instructions that arrived during task execution. Skip = stuck idle until the next nudge escalation or task reassignment.
 6. (No delivery verification needed — inbox_write guarantees persistence)
 
@@ -77,7 +77,7 @@ Act without waiting for Karo's instruction:
 - If modifying instructions → check for contradictions
 
 **Anomaly handling:**
-- Context below 30% → write progress to report YAML, tell Karo "context running low"
+- Context below 30% → write progress to report YAML, tell Gunshi "context running low"
 - Task larger than expected → include split proposal in report
 
 ## Shout Mode (echo_message)

--- a/instructions/generated/codex-ashigaru.md
+++ b/instructions/generated/codex-ashigaru.md
@@ -67,7 +67,7 @@ Act without waiting for Karo's instruction:
 1. Self-review deliverables (re-read your output)
 2. **Purpose validation**: Read `parent_cmd` in `queue/shogun_to_karo.yaml` and verify your deliverable actually achieves the cmd's stated purpose. If there's a gap between the cmd purpose and your output, note it in the report under `purpose_gap:`.
 3. Write report YAML
-4. Notify Karo via inbox_write
+4. Notify Gunshi via inbox_write (NOT Karo directly)
 5. **Check own inbox** (MANDATORY): Read `queue/inbox/ashigaru{N}.yaml`, process any `read: false` entries. This catches redo instructions that arrived during task execution. Skip = stuck idle until the next nudge escalation or task reassignment.
 6. (No delivery verification needed — inbox_write guarantees persistence)
 
@@ -77,7 +77,7 @@ Act without waiting for Karo's instruction:
 - If modifying instructions → check for contradictions
 
 **Anomaly handling:**
-- Context below 30% → write progress to report YAML, tell Karo "context running low"
+- Context below 30% → write progress to report YAML, tell Gunshi "context running low"
 - Task larger than expected → include split proposal in report
 
 ## Shout Mode (echo_message)

--- a/instructions/generated/codex-gunshi.md
+++ b/instructions/generated/codex-gunshi.md
@@ -169,6 +169,12 @@ Military strategist — knowledgeable, calm, analytical.
 
 ## Autonomous Judgment Rules
 
+**When receiving Ashigaru report** (inbox type: report_received from ashigaru):
+1. Read the report YAML from `queue/reports/ashigaru{N}_{task_id}_report.yaml`
+2. Perform QC based on task's Bloom level (see karo_role.md QC Routing)
+3. Aggregate results and forward to Karo via inbox_write with QC verdict
+4. **Do NOT contact Karo before performing QC** — Gunshi is the quality gate
+
 **On task completion** (in this order):
 1. Self-review deliverables (re-read your output)
 2. Verify recommendations are actionable (Karo must be able to use them directly)

--- a/instructions/generated/codex-karo.md
+++ b/instructions/generated/codex-karo.md
@@ -165,7 +165,7 @@ Use Gunshi for tasks that genuinely need deep thinking — don't over-route triv
 
 ## Quality Control (QC) Routing
 
-QC work is split between Karo and Gunshi. **Ashigaru never perform QC.**
+Primary QC flow is Ashigaru → Gunshi → Karo. **Ashigaru never perform QC directly.** Gunshi handles quality check and dashboard aggregation; Karo handles strategic decisions.
 
 ### Simple QC → Karo Judges Directly
 

--- a/instructions/generated/copilot-ashigaru.md
+++ b/instructions/generated/copilot-ashigaru.md
@@ -67,7 +67,7 @@ Act without waiting for Karo's instruction:
 1. Self-review deliverables (re-read your output)
 2. **Purpose validation**: Read `parent_cmd` in `queue/shogun_to_karo.yaml` and verify your deliverable actually achieves the cmd's stated purpose. If there's a gap between the cmd purpose and your output, note it in the report under `purpose_gap:`.
 3. Write report YAML
-4. Notify Karo via inbox_write
+4. Notify Gunshi via inbox_write (NOT Karo directly)
 5. **Check own inbox** (MANDATORY): Read `queue/inbox/ashigaru{N}.yaml`, process any `read: false` entries. This catches redo instructions that arrived during task execution. Skip = stuck idle until the next nudge escalation or task reassignment.
 6. (No delivery verification needed — inbox_write guarantees persistence)
 
@@ -77,7 +77,7 @@ Act without waiting for Karo's instruction:
 - If modifying instructions → check for contradictions
 
 **Anomaly handling:**
-- Context below 30% → write progress to report YAML, tell Karo "context running low"
+- Context below 30% → write progress to report YAML, tell Gunshi "context running low"
 - Task larger than expected → include split proposal in report
 
 ## Shout Mode (echo_message)

--- a/instructions/generated/copilot-gunshi.md
+++ b/instructions/generated/copilot-gunshi.md
@@ -169,6 +169,12 @@ Military strategist — knowledgeable, calm, analytical.
 
 ## Autonomous Judgment Rules
 
+**When receiving Ashigaru report** (inbox type: report_received from ashigaru):
+1. Read the report YAML from `queue/reports/ashigaru{N}_{task_id}_report.yaml`
+2. Perform QC based on task's Bloom level (see karo_role.md QC Routing)
+3. Aggregate results and forward to Karo via inbox_write with QC verdict
+4. **Do NOT contact Karo before performing QC** — Gunshi is the quality gate
+
 **On task completion** (in this order):
 1. Self-review deliverables (re-read your output)
 2. Verify recommendations are actionable (Karo must be able to use them directly)

--- a/instructions/generated/copilot-karo.md
+++ b/instructions/generated/copilot-karo.md
@@ -165,7 +165,7 @@ Use Gunshi for tasks that genuinely need deep thinking — don't over-route triv
 
 ## Quality Control (QC) Routing
 
-QC work is split between Karo and Gunshi. **Ashigaru never perform QC.**
+Primary QC flow is Ashigaru → Gunshi → Karo. **Ashigaru never perform QC directly.** Gunshi handles quality check and dashboard aggregation; Karo handles strategic decisions.
 
 ### Simple QC → Karo Judges Directly
 

--- a/instructions/generated/gunshi.md
+++ b/instructions/generated/gunshi.md
@@ -169,6 +169,12 @@ Military strategist — knowledgeable, calm, analytical.
 
 ## Autonomous Judgment Rules
 
+**When receiving Ashigaru report** (inbox type: report_received from ashigaru):
+1. Read the report YAML from `queue/reports/ashigaru{N}_{task_id}_report.yaml`
+2. Perform QC based on task's Bloom level (see karo_role.md QC Routing)
+3. Aggregate results and forward to Karo via inbox_write with QC verdict
+4. **Do NOT contact Karo before performing QC** — Gunshi is the quality gate
+
 **On task completion** (in this order):
 1. Self-review deliverables (re-read your output)
 2. Verify recommendations are actionable (Karo must be able to use them directly)

--- a/instructions/generated/karo.md
+++ b/instructions/generated/karo.md
@@ -165,7 +165,7 @@ Use Gunshi for tasks that genuinely need deep thinking — don't over-route triv
 
 ## Quality Control (QC) Routing
 
-QC work is split between Karo and Gunshi. **Ashigaru never perform QC.**
+Primary QC flow is Ashigaru → Gunshi → Karo. **Ashigaru never perform QC directly.** Gunshi handles quality check and dashboard aggregation; Karo handles strategic decisions.
 
 ### Simple QC → Karo Judges Directly
 

--- a/instructions/generated/kimi-ashigaru.md
+++ b/instructions/generated/kimi-ashigaru.md
@@ -67,7 +67,7 @@ Act without waiting for Karo's instruction:
 1. Self-review deliverables (re-read your output)
 2. **Purpose validation**: Read `parent_cmd` in `queue/shogun_to_karo.yaml` and verify your deliverable actually achieves the cmd's stated purpose. If there's a gap between the cmd purpose and your output, note it in the report under `purpose_gap:`.
 3. Write report YAML
-4. Notify Karo via inbox_write
+4. Notify Gunshi via inbox_write (NOT Karo directly)
 5. **Check own inbox** (MANDATORY): Read `queue/inbox/ashigaru{N}.yaml`, process any `read: false` entries. This catches redo instructions that arrived during task execution. Skip = stuck idle until the next nudge escalation or task reassignment.
 6. (No delivery verification needed — inbox_write guarantees persistence)
 
@@ -77,7 +77,7 @@ Act without waiting for Karo's instruction:
 - If modifying instructions → check for contradictions
 
 **Anomaly handling:**
-- Context below 30% → write progress to report YAML, tell Karo "context running low"
+- Context below 30% → write progress to report YAML, tell Gunshi "context running low"
 - Task larger than expected → include split proposal in report
 
 ## Shout Mode (echo_message)

--- a/instructions/generated/kimi-gunshi.md
+++ b/instructions/generated/kimi-gunshi.md
@@ -169,6 +169,12 @@ Military strategist — knowledgeable, calm, analytical.
 
 ## Autonomous Judgment Rules
 
+**When receiving Ashigaru report** (inbox type: report_received from ashigaru):
+1. Read the report YAML from `queue/reports/ashigaru{N}_{task_id}_report.yaml`
+2. Perform QC based on task's Bloom level (see karo_role.md QC Routing)
+3. Aggregate results and forward to Karo via inbox_write with QC verdict
+4. **Do NOT contact Karo before performing QC** — Gunshi is the quality gate
+
 **On task completion** (in this order):
 1. Self-review deliverables (re-read your output)
 2. Verify recommendations are actionable (Karo must be able to use them directly)

--- a/instructions/generated/kimi-karo.md
+++ b/instructions/generated/kimi-karo.md
@@ -165,7 +165,7 @@ Use Gunshi for tasks that genuinely need deep thinking — don't over-route triv
 
 ## Quality Control (QC) Routing
 
-QC work is split between Karo and Gunshi. **Ashigaru never perform QC.**
+Primary QC flow is Ashigaru → Gunshi → Karo. **Ashigaru never perform QC directly.** Gunshi handles quality check and dashboard aggregation; Karo handles strategic decisions.
 
 ### Simple QC → Karo Judges Directly
 

--- a/instructions/roles/ashigaru_role.md
+++ b/instructions/roles/ashigaru_role.md
@@ -66,7 +66,7 @@ Act without waiting for Karo's instruction:
 1. Self-review deliverables (re-read your output)
 2. **Purpose validation**: Read `parent_cmd` in `queue/shogun_to_karo.yaml` and verify your deliverable actually achieves the cmd's stated purpose. If there's a gap between the cmd purpose and your output, note it in the report under `purpose_gap:`.
 3. Write report YAML
-4. Notify Karo via inbox_write
+4. Notify Gunshi via inbox_write (NOT Karo directly)
 5. **Check own inbox** (MANDATORY): Read `queue/inbox/ashigaru{N}.yaml`, process any `read: false` entries. This catches redo instructions that arrived during task execution. Skip = stuck idle until the next nudge escalation or task reassignment.
 6. (No delivery verification needed — inbox_write guarantees persistence)
 
@@ -76,7 +76,7 @@ Act without waiting for Karo's instruction:
 - If modifying instructions → check for contradictions
 
 **Anomaly handling:**
-- Context below 30% → write progress to report YAML, tell Karo "context running low"
+- Context below 30% → write progress to report YAML, tell Gunshi "context running low"
 - Task larger than expected → include split proposal in report
 
 ## Shout Mode (echo_message)

--- a/instructions/roles/gunshi_role.md
+++ b/instructions/roles/gunshi_role.md
@@ -168,6 +168,12 @@ Military strategist — knowledgeable, calm, analytical.
 
 ## Autonomous Judgment Rules
 
+**When receiving Ashigaru report** (inbox type: report_received from ashigaru):
+1. Read the report YAML from `queue/reports/ashigaru{N}_{task_id}_report.yaml`
+2. Perform QC based on task's Bloom level (see karo_role.md QC Routing)
+3. Aggregate results and forward to Karo via inbox_write with QC verdict
+4. **Do NOT contact Karo before performing QC** — Gunshi is the quality gate
+
 **On task completion** (in this order):
 1. Self-review deliverables (re-read your output)
 2. Verify recommendations are actionable (Karo must be able to use them directly)

--- a/instructions/roles/karo_role.md
+++ b/instructions/roles/karo_role.md
@@ -164,7 +164,7 @@ Use Gunshi for tasks that genuinely need deep thinking — don't over-route triv
 
 ## Quality Control (QC) Routing
 
-QC work is split between Karo and Gunshi. **Ashigaru never perform QC.**
+Primary QC flow is Ashigaru → Gunshi → Karo. **Ashigaru never perform QC directly.** Gunshi handles quality check and dashboard aggregation; Karo handles strategic decisions.
 
 ### Simple QC → Karo Judges Directly
 

--- a/scripts/dashboard-viewer.py
+++ b/scripts/dashboard-viewer.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""
+dashboard-viewer.py
+
+Serves dashboard.md as a browser-viewable page with auto-refresh on file change.
+Uses only Python3 standard library. No pip install required.
+
+Usage:
+    python3 scripts/dashboard-viewer.py
+"""
+
+import http.server
+import json
+import os
+import subprocess
+import sys
+import threading
+import webbrowser
+from pathlib import Path
+
+PORT = 8787
+
+HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dashboard</title>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <style>
+    :root {
+      --bg: #0d1117;
+      --surface: #161b22;
+      --border: #30363d;
+      --text: #c9d1d9;
+      --heading: #e6edf3;
+      --accent: #58a6ff;
+      --code-bg: #1c2128;
+      --muted: #8b949e;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 14px;
+      line-height: 1.6;
+      height: 100%;
+    }
+    #app {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 16px 20px 40px;
+    }
+    #status-bar {
+      position: fixed;
+      top: 0; left: 0; right: 0;
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      padding: 4px 12px;
+      font-size: 11px;
+      color: var(--muted);
+      z-index: 100;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    #status-bar .dot {
+      display: inline-block;
+      width: 7px; height: 7px;
+      border-radius: 50%;
+      background: #3fb950;
+      margin-right: 5px;
+      vertical-align: middle;
+    }
+    #status-bar .dot.stale { background: #f85149; }
+    #content {
+      margin-top: 32px;
+    }
+    /* Markdown styles */
+    #content h1, #content h2, #content h3,
+    #content h4, #content h5, #content h6 {
+      color: var(--heading);
+      border-bottom: 1px solid var(--border);
+      padding-bottom: 6px;
+      margin: 20px 0 10px;
+    }
+    #content h1 { font-size: 1.5em; }
+    #content h2 { font-size: 1.25em; }
+    #content h3 { font-size: 1.1em; border-bottom: none; }
+    #content p { margin: 8px 0; }
+    #content ul, #content ol {
+      margin: 6px 0 6px 20px;
+    }
+    #content li { margin: 2px 0; }
+    #content code {
+      background: var(--code-bg);
+      padding: 1px 5px;
+      border-radius: 4px;
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+      font-size: 0.9em;
+    }
+    #content pre {
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 12px;
+      overflow-x: auto;
+      margin: 10px 0;
+    }
+    #content pre code {
+      background: none;
+      padding: 0;
+    }
+    #content blockquote {
+      border-left: 3px solid var(--border);
+      padding-left: 12px;
+      color: var(--muted);
+      margin: 8px 0;
+    }
+    #content table {
+      border-collapse: collapse;
+      width: 100%;
+      margin: 10px 0;
+      font-size: 0.92em;
+    }
+    #content th, #content td {
+      border: 1px solid var(--border);
+      padding: 5px 10px;
+      text-align: left;
+    }
+    #content th {
+      background: var(--surface);
+      color: var(--heading);
+    }
+    #content a {
+      color: var(--accent);
+      text-decoration: none;
+    }
+    #content a:hover { text-decoration: underline; }
+    #content hr {
+      border: none;
+      border-top: 1px solid var(--border);
+      margin: 16px 0;
+    }
+  </style>
+</head>
+<body>
+  <div id="status-bar">
+    <span><span class="dot" id="dot"></span><span id="status-text">Connecting...</span></span>
+    <span id="last-updated"></span>
+  </div>
+  <div id="app">
+    <div id="content"><em>Loading...</em></div>
+  </div>
+  <script>
+    let lastMtime = null;
+    const dot = document.getElementById('dot');
+    const statusText = document.getElementById('status-text');
+    const lastUpdated = document.getElementById('last-updated');
+    const contentEl = document.getElementById('content');
+
+    async function fetchMtime() {
+      const res = await fetch('/api/mtime');
+      const data = await res.json();
+      return data.mtime;
+    }
+
+    async function fetchDashboard() {
+      const res = await fetch('/api/dashboard');
+      return await res.text();
+    }
+
+    async function render() {
+      const md = await fetchDashboard();
+      contentEl.innerHTML = marked.parse(md);
+    }
+
+    function setStatus(ok, text) {
+      dot.className = 'dot' + (ok ? '' : ' stale');
+      statusText.textContent = text;
+    }
+
+    async function poll() {
+      try {
+        const mtime = await fetchMtime();
+        if (mtime !== lastMtime) {
+          lastMtime = mtime;
+          await render();
+          const d = new Date();
+          lastUpdated.textContent = 'Updated ' + d.toLocaleTimeString('ja-JP');
+        }
+        setStatus(true, 'Live');
+      } catch (e) {
+        setStatus(false, 'Connection error');
+      }
+    }
+
+    poll();
+    setInterval(poll, 1500);
+  </script>
+</body>
+</html>
+"""
+
+
+def get_repo_root() -> Path:
+    """Resolve the git repository root."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return Path(result.stdout.strip())
+    except subprocess.CalledProcessError:
+        # Fall back to the directory containing this script's parent
+        return Path(__file__).resolve().parent.parent
+
+
+class DashboardHandler(http.server.BaseHTTPRequestHandler):
+    dashboard_path: Path  # set before server starts
+
+    def log_message(self, fmt, *args):
+        # Suppress default access log to keep terminal clean
+        pass
+
+    def do_GET(self):
+        if self.path == "/":
+            self._serve_html()
+        elif self.path == "/api/dashboard":
+            self._serve_markdown()
+        elif self.path == "/api/mtime":
+            self._serve_mtime()
+        else:
+            self.send_error(404)
+
+    def _serve_html(self):
+        body = HTML_TEMPLATE.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _serve_markdown(self):
+        try:
+            text = self.dashboard_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            self.send_error(404, "dashboard.md not found")
+            return
+        body = text.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _serve_mtime(self):
+        try:
+            mtime = self.dashboard_path.stat().st_mtime
+        except FileNotFoundError:
+            self.send_error(404, "dashboard.md not found")
+            return
+        body = json.dumps({"mtime": mtime}).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def main():
+    repo_root = get_repo_root()
+    dashboard_path = repo_root / "dashboard.md"
+
+    if not dashboard_path.exists():
+        print(f"Error: dashboard.md not found at {dashboard_path}", file=sys.stderr)
+        sys.exit(1)
+
+    # Inject path into handler class
+    DashboardHandler.dashboard_path = dashboard_path
+
+    import socket
+
+    try:
+        server = http.server.HTTPServer(("127.0.0.1", PORT), DashboardHandler)
+    except OSError as e:
+        if e.errno == 48 or e.errno == 98:  # Address already in use (macOS=48, Linux=98)
+            print(
+                f"Error: Port {PORT} is already in use. "
+                "Another instance may be running.",
+                file=sys.stderr,
+            )
+        else:
+            print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    url = f"http://127.0.0.1:{PORT}"
+    print(f"Dashboard viewer running at {url}")
+    print(f"Serving: {dashboard_path}")
+    print("Press Ctrl+C to stop.")
+
+    # Open browser after a short delay so the server is ready
+    def open_browser():
+        import time
+        time.sleep(0.3)
+        webbrowser.open(url)
+
+    threading.Thread(target=open_browser, daemon=True).start()
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopped.")
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/inbox_write.sh
+++ b/scripts/inbox_write.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # inbox_write.sh — メールボックスへのメッセージ書き込み（排他ロック付き）
-# Usage: bash scripts/inbox_write.sh <target_agent> <content> [type] [from]
+# Usage: bash scripts/inbox_write.sh <target_agent> <content> <type> <from>
 # Example: bash scripts/inbox_write.sh karo "足軽5号、任務完了" report_received ashigaru5
 
 set -e
@@ -8,15 +8,21 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TARGET="$1"
 CONTENT="$2"
-TYPE="${3:-wake_up}"
-FROM="${4:-unknown}"
+TYPE="$3"
+FROM="$4"
 
 INBOX="$SCRIPT_DIR/queue/inbox/${TARGET}.yaml"
 LOCKFILE="${INBOX}.lock"
 
 # Validate arguments
-if [ -z "$TARGET" ] || [ -z "$CONTENT" ]; then
-    echo "Usage: inbox_write.sh <target_agent> <content> [type] [from]" >&2
+if [ -z "$TARGET" ] || [ -z "$CONTENT" ] || [ -z "$TYPE" ] || [ -z "$FROM" ]; then
+    echo "Usage: inbox_write.sh <target_agent> <content> <type> <from>" >&2
+    exit 1
+fi
+
+# Self-send guard: reject messages where sender == target
+if [ "$FROM" = "$TARGET" ]; then
+    echo "[inbox_write] REJECTED: self-send detected (from=$FROM, target=$TARGET)" >&2
     exit 1
 fi
 

--- a/tests/test_inbox_write.bats
+++ b/tests/test_inbox_write.bats
@@ -75,6 +75,26 @@ teardown() {
 }
 
 # =============================================================================
+# T-002b: 引数バリデーション — type/from未指定でexit 1
+# =============================================================================
+
+@test "T-002b: missing type and from → exit 1" {
+    run bash "$TEST_INBOX_WRITE" "test_agent" "content only"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Usage" ]]
+}
+
+# =============================================================================
+# T-002c: 自己送信ガード — from==targetでexit 1
+# =============================================================================
+
+@test "T-002c: self-send (from==target) → exit 1 with REJECTED" {
+    run bash "$TEST_INBOX_WRITE" "karo" "self message" "cmd_new" "karo"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "REJECTED" ]]
+}
+
+# =============================================================================
 # T-003: 正常書き込み — 新規inboxファイル作成
 # =============================================================================
 
@@ -149,8 +169,8 @@ EOF
 
 @test "T-005: message ID uniqueness → 2 rapid writes produce different IDs" {
     # 2回連続書き込み
-    bash "$TEST_INBOX_WRITE" "test_agent" "メッセージA"
-    bash "$TEST_INBOX_WRITE" "test_agent" "メッセージB"
+    bash "$TEST_INBOX_WRITE" "test_agent" "メッセージA" "test_type" "sender_a"
+    bash "$TEST_INBOX_WRITE" "test_agent" "メッセージB" "test_type" "sender_b"
 
     # python3で検証
     "$VENV_PYTHON" <<EOF
@@ -174,24 +194,10 @@ EOF
 # T-006: デフォルト値 — type未指定でwake_up
 # =============================================================================
 
-@test "T-006: type/from default values → type=wake_up, from=unknown when not specified" {
+@test "T-006: missing type/from → exit 1 with Usage message" {
     run bash "$TEST_INBOX_WRITE" "test_agent" "デフォルトテスト"
-    [ "$status" -eq 0 ]
-
-    # python3で検証
-    "$VENV_PYTHON" <<EOF
-import yaml
-
-with open('$TEST_INBOX_DIR/test_agent.yaml') as f:
-    data = yaml.safe_load(f)
-
-msg = data['messages'][0]
-
-assert msg['type'] == 'wake_up', f'Expected type=wake_up, got {msg["type"]}'
-assert msg['from'] == 'unknown', f'Expected from=unknown, got {msg["from"]}'
-
-print('T-006: PASS')
-EOF
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Usage" ]]
 }
 
 # =============================================================================
@@ -245,7 +251,7 @@ with open('$TEST_INBOX_DIR/test_agent.yaml', 'w') as f:
 EOF
 
     # 新規メッセージ1件書き込み
-    run bash "$TEST_INBOX_WRITE" "test_agent" "新規メッセージ"
+    run bash "$TEST_INBOX_WRITE" "test_agent" "新規メッセージ" "test_type" "other_sender"
     [ "$status" -eq 0 ]
 
     # 検証: 合計50件以下、新規メッセージは存在
@@ -305,7 +311,7 @@ with open('$TEST_INBOX_DIR/test_agent.yaml', 'w') as f:
 EOF
 
     # 新規メッセージ1件書き込み（未読20→21件になる）
-    run bash "$TEST_INBOX_WRITE" "test_agent" "新規未読"
+    run bash "$TEST_INBOX_WRITE" "test_agent" "新規未読" "test_type" "other_sender"
     [ "$status" -eq 0 ]
 
     # 検証: 未読21件が全て保持される
@@ -380,7 +386,7 @@ EOF
 ブレース: {key: value}
 配列: [1, 2, 3]"
 
-    run bash "$TEST_INBOX_WRITE" "test_agent" "$SPECIAL_CONTENT"
+    run bash "$TEST_INBOX_WRITE" "test_agent" "$SPECIAL_CONTENT" "test_type" "other_sender"
     [ "$status" -eq 0 ]
 
     # 検証: 特殊文字が正しく保存・復元されること
@@ -416,7 +422,7 @@ EOF
     [ ! -d "$TEST_INBOX_DIR" ]
 
     # メッセージ書き込み
-    run bash "$TEST_INBOX_WRITE" "test_agent" "自動作成テスト"
+    run bash "$TEST_INBOX_WRITE" "test_agent" "自動作成テスト" "test_type" "other_sender"
     [ "$status" -eq 0 ]
 
     # ディレクトリとファイルが作成されていることを確認


### PR DESCRIPTION
## Summary

- upstream (yohey-w/multi-agent-shogun) main の10コミットを `git merge` で統合
- 競合5ファイルを手動解決（fork独自ルール保持）
- 新規追加: `scripts/dashboard-viewer.py`, `.github/FUNDING.yml`

## 競合解決方針

fork独自の以下は全て保持:
- bloom_routing / QC ゲート ルール
- Karo Mandatory Rules（タスク完了時の必須アクション・/clearルール）
- /clear Recovery Step 3.5（status→in_progress）・Step 6（echo_shout必須）
- reports ファイル構造: task-unit形式（ashigaru → gunshi → karo のフロー）
- `.gitignore` fork独自スクリプト除外設定

upstream から追加:
- `/clear Recovery Step 3` に `done=wait (DO NOT re-report)` 追記
- `scripts/dashboard-viewer.py` 追加

## テスト

- pre-commit hook: 37件全通過、SKIP=0

## 注意

**自動マージ禁止。殿の確認後にマージせよ。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)