### PR TITLE
🔄 upstream v4.6.0 を merge で取り込み (close #85)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -132,8 +132,8 @@ Examples:
 # Shogun → Karo
 bash scripts/inbox_write.sh karo "cmd_048を書いた。実行せよ。" cmd_new shogun
 
-# Ashigaru → Karo
-bash scripts/inbox_write.sh karo "足軽5号、任務完了。報告YAML確認されたし。" report_received ashigaru5
+# Ashigaru → Gunshi
+bash scripts/inbox_write.sh gunshi "足軽5号、任務完了。品質チェックを仰ぎたし。" report_received ashigaru5
 
 # Karo → Ashigaru
 bash scripts/inbox_write.sh ashigaru3 "タスクYAMLを読んで作業開始せよ。" task_assigned karo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,8 +132,8 @@ Examples:
 # Shogun → Karo
 bash scripts/inbox_write.sh karo "cmd_048を書いた。実行せよ。" cmd_new shogun
 
-# Ashigaru → Karo
-bash scripts/inbox_write.sh karo "足軽5号、任務完了。報告YAML確認されたし。" report_received ashigaru5
+# Ashigaru → Gunshi
+bash scripts/inbox_write.sh gunshi "足軽5号、任務完了。品質チェックを仰ぎたし。" report_received ashigaru5
 
 # Karo → Ashigaru
 bash scripts/inbox_write.sh ashigaru3 "タスクYAMLを読んで作業開始せよ。" task_assigned karo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.6.0] - 2026-04-19
+
+### Added
+- `shutsujin_departure.sh`: `--auto-mode-on` flag (maps to `--dangerously-skip-permissions`) and `--permission-mode <mode>` for custom permission flags (Issue #124)
+- `lib/cli_adapter.sh`: accept `PERMISSION_FLAG` override from departure script, backward-compatible
+
+### Fixed
+- Report flow unified to `Ashigaru → Gunshi → Karo` across all instruction files (`instructions/ashigaru.md`, `karo.md`, `gunshi.md`, `CLAUDE.md`, all generated CLI variants) (Issue #121)
+
+### Changed
+- `PERMISSION_FLAG` variable centralizes permission handling in `shutsujin_departure.sh` (10 call sites)
+- `tests/unit/test_cli_adapter.bats`: additional coverage for permission flag logic
+
 ## [4.5.0] - 2026-04-19
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ files:
   tasks: "queue/tasks/ashigaru{N}.yaml" # Karo → Ashigaru assignments (per-ashigaru)
   gunshi_task: queue/tasks/gunshi.yaml  # Karo → Gunshi strategic assignments
   pending_tasks: queue/tasks/pending.yaml # Karo管理の保留タスク（blocked未割当）
-  reports: "queue/reports/ashigaru{N}_report.yaml" # Ashigaru → Karo reports
+  reports: "queue/reports/ashigaru{N}_report.yaml" # Ashigaru → Gunshi reports
   gunshi_report: queue/reports/gunshi_report.yaml  # Gunshi → Karo strategic reports
   dashboard: dashboard.md              # Human-readable summary (secondary data)
   daily_log: "logs/daily/YYYY-MM-DD.md" # Karo appends cmd summary on completion. Shogun reads for daily reports.
@@ -121,8 +121,8 @@ Examples:
 # Shogun → Karo
 bash scripts/inbox_write.sh karo "cmd_048を書いた。実行せよ。" cmd_new shogun
 
-# Ashigaru → Karo
-bash scripts/inbox_write.sh karo "足軽5号、任務完了。報告YAML確認されたし。" report_received ashigaru5
+# Ashigaru → Gunshi
+bash scripts/inbox_write.sh gunshi "足軽5号、任務完了。品質チェックを仰ぎたし。" report_received ashigaru5
 
 # Karo → Ashigaru
 bash scripts/inbox_write.sh ashigaru3 "タスクYAMLを読んで作業開始せよ。" task_assigned karo

--- a/agents/default/system.md
+++ b/agents/default/system.md
@@ -132,8 +132,8 @@ Examples:
 # Shogun → Karo
 bash scripts/inbox_write.sh karo "cmd_048を書いた。実行せよ。" cmd_new shogun
 
-# Ashigaru → Karo
-bash scripts/inbox_write.sh karo "足軽5号、任務完了。報告YAML確認されたし。" report_received ashigaru5
+# Ashigaru → Gunshi
+bash scripts/inbox_write.sh gunshi "足軽5号、任務完了。品質チェックを仰ぎたし。" report_received ashigaru5
 
 # Karo → Ashigaru
 bash scripts/inbox_write.sh ashigaru3 "タスクYAMLを読んで作業開始せよ。" task_assigned karo

--- a/instructions/ashigaru.md
+++ b/instructions/ashigaru.md
@@ -10,12 +10,12 @@ version: "2.1"
 forbidden_actions:
   - id: F001
     action: direct_shogun_report
-    description: "Report directly to Shogun (bypass Karo)"
-    report_to: karo
+    description: "Report directly to Shogun (bypass Gunshi/Karo chain)"
+    report_to: gunshi
   - id: F002
     action: direct_user_contact
     description: "Contact human directly"
-    report_to: karo
+    report_to: gunshi
   - id: F003
     action: unauthorized_work
     description: "Perform work not assigned"
@@ -125,7 +125,7 @@ persona:
 
 skill_candidate:
   criteria: [reusable across projects, pattern repeated 2+ times, requires specialized knowledge, useful to other ashigaru]
-  action: report_to_karo
+  action: report_to_gunshi
 
 ---
 
@@ -271,8 +271,9 @@ Act without waiting for Karo's instruction:
 1. Self-review deliverables (re-read your output)
 2. **Purpose validation**: Read `parent_cmd` in `queue/shogun_to_karo.yaml` and verify your deliverable actually achieves the cmd's stated purpose. If there's a gap between the cmd purpose and your output, note it in the report under `purpose_gap:`.
 3. Write report YAML
-4. Notify Karo via inbox_write
-5. (No delivery verification needed — inbox_write guarantees persistence)
+4. Notify Gunshi via inbox_write
+5. **Check own inbox** (MANDATORY): Read `queue/inbox/ashigaru{N}.yaml`, process any `read: false` entries
+6. (No delivery verification needed — inbox_write guarantees persistence)
 
 **Quality assurance:**
 - After modifying files → verify with Read
@@ -280,7 +281,7 @@ Act without waiting for Karo's instruction:
 - If modifying instructions → check for contradictions
 
 **Anomaly handling:**
-- Context below 30% → write progress to report YAML, tell Karo "context running low"
+- Context below 30% → write progress to report YAML, tell Gunshi "context running low"
 - Task larger than expected → include split proposal in report
 
 ## Shout Mode (echo_message)

--- a/instructions/gunshi.md
+++ b/instructions/gunshi.md
@@ -32,6 +32,11 @@ workflow:
     action: receive_wakeup
     from: karo
     via: inbox
+  - step: 1.2
+    action: receive_quality_report
+    from: ashigaru
+    via: inbox
+    note: "Ashigaru completion reports arrive here first for quality check and dashboard aggregation."
   - step: 1.5
     action: yaml_slim
     command: 'bash scripts/slim_yaml.sh gunshi'

--- a/instructions/karo.md
+++ b/instructions/karo.md
@@ -277,7 +277,8 @@ Report via dashboard.md update only. Reason: interrupt prevention during lord's 
 ```
 ✅ Correct (event-driven):
   cmd_008 dispatch → inbox_write ashigaru → stop (await inbox wakeup)
-  → ashigaru completes → inbox_write karo → karo wakes → process report
+  → ashigaru completes → inbox_write gunshi → gunshi QC → inbox_write karo
+  → karo wakes → process report
 
 ❌ Wrong (polling):
   cmd_008 dispatch → sleep 30 → capture-pane → check status → sleep 30 ...
@@ -287,7 +288,7 @@ Report via dashboard.md update only. Reason: interrupt prevention during lord's 
 
 1. List all pending cmds in `queue/shogun_to_karo.yaml`
 2. For each cmd: decompose → write YAML → inbox_write → **next cmd immediately**
-3. After all cmds dispatched: **stop** (await inbox wakeup from ashigaru)
+3. After all cmds dispatched: **stop** (await inbox wakeup from gunshi)
 4. On wakeup: scan reports → process → check for more pending cmds → stop
 
 ## Task Design: Five Questions
@@ -346,7 +347,7 @@ Claude Code cannot "wait". Prompt-wait = stopped.
 
 1. Dispatch ashigaru
 2. Say "stopping here" and end processing
-3. Ashigaru wakes you via inbox
+3. Gunshi wakes you via inbox after QC
 4. Scan ALL report files (not just the reporting one)
 5. Assess situation, then act
 
@@ -358,13 +359,13 @@ Claude Code cannot "wait". Prompt-wait = stopped.
 Step 7: Dispatch cmd_N subtasks → inbox_write to ashigaru
 Step 8: check_pending → if pending cmd_N+1, process it → then STOP
   → Karo becomes idle (prompt waiting)
-Step 9: Ashigaru completes → inbox_write karo → watcher nudges karo
+Step 9: Ashigaru completes → inbox_write gunshi → Gunshi QC → inbox_write karo
   → Karo wakes, scans reports, acts
 ```
 
-**Why no background monitor**: inbox_watcher.sh detects ashigaru's inbox_write to karo and sends a nudge. This is true event-driven. No sleep, no polling, no CPU waste.
+**Why no background monitor**: inbox_watcher.sh detects gunshi's inbox_write to karo and sends a nudge. This is true event-driven. No sleep, no polling, no CPU waste.
 
-**Karo wakes via**: inbox nudge from ashigaru report, shogun new cmd, or system event. Nothing else.
+**Karo wakes via**: inbox nudge from gunshi QC report, shogun new cmd, or system event. Nothing else.
 
 ## Report Scanning (Communication Loss Safety)
 
@@ -468,7 +469,7 @@ Push notifications to the lord's phone via ntfy. Karo manages streaks and notifi
 |-------|------|----------------|
 | cmd complete | All subtasks of a parent_cmd are done | `✅ cmd_XXX 完了！({N}サブタスク) 🔥ストリーク{current}日目` |
 | Frog complete | Completed task matches `today.frog` | `🐸✅ Frog撃破！cmd_XXX 完了！...` |
-| Subtask failed | Ashigaru reports `status: failed` | `❌ subtask_XXX 失敗 — {reason summary, max 50 chars}` |
+| Subtask failed | Gunshi QC or report scan confirms `status: failed` | `❌ subtask_XXX 失敗 — {reason summary, max 50 chars}` |
 | cmd failed | All subtasks done, any failed | `❌ cmd_XXX 失敗 ({M}/{N}完了, {F}失敗)` |
 | Action needed | 🚨 section added to dashboard.md | `🚨 要対応: {heading}` |
 | **Frog selected** | **Frog auto-selected or manually set** | `🐸 今日のFrog: {title} [{category}]` |
@@ -618,7 +619,7 @@ Note: This replaces the need for inbox_write to shogun. ntfy goes directly to Lo
 
 ## Skill Candidates
 
-On receiving ashigaru reports, check `skill_candidate` field. If found:
+When processing report scan results, check `queue/reports/ashigaru*_report.yaml` `skill_candidate` fields. If found:
 1. Dedup check
 2. Add to dashboard.md "スキル化候補" section
 3. **Also add summary to 🚨 要対応** (lord's approval needed)
@@ -803,11 +804,21 @@ When Gunshi completes:
 
 ### Quality Control (QC) Routing
 
-QC work is split between Karo and Gunshi. **Ashigaru never perform QC.**
+Primary QC flow is **Ashigaru → Gunshi → Karo**. **Ashigaru never perform QC.**
 
-#### Simple QC → Karo Judges Directly
+#### Primary QC → Gunshi Reviews All Ashigaru Completions
 
-When ashigaru reports task completion, Karo handles these checks directly (no Gunshi delegation needed):
+When ashigaru completes a task, Gunshi performs the first-pass QC and reports PASS/FAIL to Karo.
+
+| Check | Owner |
+|-------|-------|
+| Deliverables exist and match task YAML | Gunshi |
+| Tests/build/scope review | Gunshi |
+| Dashboard QC aggregation | Gunshi |
+
+#### Final Judgment → Karo May Run Fast Mechanical Spot Checks
+
+After Gunshi's QC report arrives, Karo may run fast mechanical checks before marking the parent cmd done:
 
 | Check | Method |
 |-------|--------|
@@ -816,22 +827,11 @@ When ashigaru reports task completion, Karo handles these checks directly (no Gu
 | File naming conventions | Glob pattern check |
 | done_keywords.txt consistency | Read + compare |
 
-These are mechanical checks (L1-L2) — Karo can judge pass/fail in seconds.
-
-#### Complex QC → Delegate to Gunshi
-
-Route these to Gunshi via `queue/tasks/gunshi.yaml`:
-
-| Check | Bloom Level | Why Gunshi |
-|-------|-------------|------------|
-| Design review | L5 Evaluate | Requires architectural judgment |
-| Root cause investigation | L4 Analyze | Deep reasoning needed |
-| Architecture analysis | L5-L6 | Multi-factor evaluation |
+These checks supplement Gunshi's QC. They do **not** replace the Ashigaru → Gunshi → Karo flow.
 
 #### No QC for Ashigaru
 
-**Never assign QC tasks to ashigaru.** Haiku models are unsuitable for quality judgment.
-Ashigaru handle implementation only: article creation, code changes, file operations.
+**Never assign QC tasks to ashigaru.** Ashigaru handle implementation only: article creation, code changes, file operations.
 
 ## Model Configuration
 

--- a/lib/cli_adapter.sh
+++ b/lib/cli_adapter.sh
@@ -131,6 +131,7 @@ build_cli_command() {
     model=$(get_agent_model "$agent_id")
     local thinking
     thinking=$(_cli_adapter_read_yaml "cli.agents.${agent_id}.thinking" "")
+    local permission_flag="${PERMISSION_FLAG:---dangerously-skip-permissions}"
 
     # thinking prefix: Claude CLI でのみ有効
     # thinking: true or 未設定 → そのまま（デフォルトでThinking ON）
@@ -146,7 +147,7 @@ build_cli_command() {
             if [[ -n "$model" ]]; then
                 cmd="$cmd --model $model"
             fi
-            cmd="$cmd --dangerously-skip-permissions"
+            cmd="$cmd $permission_flag"
             echo "${prefix}${cmd}"
             ;;
         codex)
@@ -168,7 +169,7 @@ build_cli_command() {
             echo "$cmd"
             ;;
         *)
-            echo "claude --dangerously-skip-permissions"
+            echo "claude $permission_flag"
             ;;
     esac
 }

--- a/shutsujin_departure.sh
+++ b/shutsujin_departure.sh
@@ -6,6 +6,8 @@
 #   ./shutsujin_departure.sh           # 全エージェント起動（前回の状態を維持）
 #   ./shutsujin_departure.sh -c        # キューをリセットして起動（クリーンスタート）
 #   ./shutsujin_departure.sh -s        # セットアップのみ（Claude起動なし）
+#   ./shutsujin_departure.sh --auto-mode-on          # Claude permission auto-approved で起動
+#   ./shutsujin_departure.sh --permission-mode plan  # Claude permission mode を明示指定
 #   ./shutsujin_departure.sh -h        # ヘルプ表示
 
 set -e
@@ -121,6 +123,8 @@ KESSEN_MODE=false
 SHOGUN_NO_THINKING=false
 SILENT_MODE=false
 SHELL_OVERRIDE=""
+# Permission flag (default: dangerously-skip-permissions for backward compat)
+PERMISSION_FLAG="--dangerously-skip-permissions"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -143,6 +147,19 @@ while [[ $# -gt 0 ]]; do
         --shogun-no-thinking)
             SHOGUN_NO_THINKING=true
             shift
+            ;;
+        --auto-mode-on)
+            PERMISSION_FLAG="--permission-mode auto-approved"
+            shift
+            ;;
+        --permission-mode)
+            if [[ -n "$2" && "$2" != -* ]]; then
+                PERMISSION_FLAG="--permission-mode $2"
+                shift 2
+            else
+                echo "エラー: --permission-mode オプションにはモード名を指定してください"
+                exit 1
+            fi
             ;;
         -S|--silent)
             SILENT_MODE=true
@@ -172,6 +189,8 @@ while [[ $# -gt 0 ]]; do
             echo "  -t, --terminal      Windows Terminal で新しいタブを開く"
             echo "  -shell, --shell SH  シェルを指定（bash または zsh）"
             echo "                      未指定時は config/settings.yaml の設定を使用"
+            echo "  --auto-mode-on      Claude を --permission-mode auto-approved で起動"
+            echo "  --permission-mode M Claude の permission mode を明示指定"
             echo "  -S, --silent        サイレントモード（足軽の戦国echo表示を無効化・API節約）"
             echo "                      未指定時はshoutモード（タスク完了時に戦国風echo表示）"
             echo "  -h, --help          このヘルプを表示"
@@ -186,6 +205,8 @@ while [[ $# -gt 0 ]]; do
             echo "  ./shutsujin_departure.sh -c -k         # クリーンスタート＋決戦の陣"
             echo "  ./shutsujin_departure.sh -shell zsh   # zsh用プロンプトで起動"
             echo "  ./shutsujin_departure.sh --shogun-no-thinking  # 将軍のthinkingを無効化（中継特化）"
+            echo "  ./shutsujin_departure.sh --auto-mode-on        # permission auto-approved で起動"
+            echo "  ./shutsujin_departure.sh --permission-mode plan  # permission mode を明示指定"
             echo "  ./shutsujin_departure.sh -S           # サイレントモード（echo表示なし）"
             echo ""
             echo "モデル構成:"
@@ -660,7 +681,7 @@ if [ "$SETUP_ONLY" = false ]; then
 
     # 将軍: CLI Adapter経由でコマンド構築
     _shogun_cli_type="claude"
-    _shogun_cmd="claude --model opus --effort max --dangerously-skip-permissions"
+    _shogun_cmd="claude --model opus --effort max $PERMISSION_FLAG"
     if [ "$CLI_ADAPTER_LOADED" = true ]; then
         _shogun_cli_type=$(get_cli_type "shogun")
         _shogun_cmd=$(build_cli_command "shogun")
@@ -690,7 +711,7 @@ with open(f,'w') as fh: yaml.safe_dump(d, fh, default_flow_style=False, allow_un
     # 家老（pane 0）: CLI Adapter経由でコマンド構築（デフォルト: Sonnet）
     p=$((PANE_BASE + 0))
     _karo_cli_type="claude"
-    _karo_cmd="claude --model sonnet --effort max --dangerously-skip-permissions"
+    _karo_cmd="claude --model sonnet --effort max $PERMISSION_FLAG"
     if [ "$CLI_ADAPTER_LOADED" = true ]; then
         _karo_cli_type=$(get_cli_type "karo")
         _karo_cmd=$(build_cli_command "karo")
@@ -712,11 +733,11 @@ with open(f,'w') as fh: yaml.safe_dump(d, fh, default_flow_style=False, allow_un
         for i in $(seq 1 "$_ASHIGARU_COUNT"); do
             p=$((PANE_BASE + i))
             _ashi_cli_type="claude"
-            _ashi_cmd="claude --model opus --effort max --dangerously-skip-permissions"
+            _ashi_cmd="claude --model opus --effort max $PERMISSION_FLAG"
             if [ "$CLI_ADAPTER_LOADED" = true ]; then
                 _ashi_cli_type=$(get_cli_type "ashigaru${i}")
                 if [ "$_ashi_cli_type" = "claude" ]; then
-                    _ashi_cmd="claude --model opus --effort max --dangerously-skip-permissions"
+                    _ashi_cmd="claude --model opus --effort max $PERMISSION_FLAG"
                 else
                     _ashi_cmd=$(build_cli_command "ashigaru${i}")
                 fi
@@ -736,7 +757,7 @@ with open(f,'w') as fh: yaml.safe_dump(d, fh, default_flow_style=False, allow_un
         for i in $(seq 1 "$_ASHIGARU_COUNT"); do
             p=$((PANE_BASE + i))
             _ashi_cli_type="claude"
-            _ashi_cmd="claude --model sonnet --effort max --dangerously-skip-permissions"
+            _ashi_cmd="claude --model sonnet --effort max $PERMISSION_FLAG"
             if [ "$CLI_ADAPTER_LOADED" = true ]; then
                 _ashi_cli_type=$(get_cli_type "ashigaru${i}")
                 _ashi_cmd=$(build_cli_command "ashigaru${i}")
@@ -756,7 +777,7 @@ with open(f,'w') as fh: yaml.safe_dump(d, fh, default_flow_style=False, allow_un
     # 軍師（pane _ASHIGARU_COUNT+1）: Opus Thinking — 戦略立案・設計判断専任
     p=$((PANE_BASE + _ASHIGARU_COUNT + 1))
     _gunshi_cli_type="claude"
-    _gunshi_cmd="claude --model opus --effort max --dangerously-skip-permissions"
+    _gunshi_cmd="claude --model opus --effort max $PERMISSION_FLAG"
     if [ "$CLI_ADAPTER_LOADED" = true ]; then
         _gunshi_cli_type=$(get_cli_type "gunshi")
         _gunshi_cmd=$(build_cli_command "gunshi")
@@ -1035,12 +1056,12 @@ if [ "$SETUP_ONLY" = true ]; then
     echo "  ┌──────────────────────────────────────────────────────────┐"
     echo "  │  # 将軍を召喚                                            │"
     echo "  │  tmux send-keys -t shogun:main \\                         │"
-    echo "  │    'claude --dangerously-skip-permissions' Enter         │"
+    echo "  │    'claude ${PERMISSION_FLAG}' Enter         │"
     echo "  │                                                          │"
     echo "  │  # 家老・足軽を一斉召喚                                  │"
     echo "  │  for p in \$(seq $PANE_BASE $((PANE_BASE+8))); do                                 │"
     echo "  │      tmux send-keys -t multiagent:agents.\$p \\            │"
-    echo "  │      'claude --dangerously-skip-permissions' Enter       │"
+    echo "  │      'claude ${PERMISSION_FLAG}' Enter       │"
     echo "  │  done                                                    │"
     echo "  └──────────────────────────────────────────────────────────┘"
     echo ""

--- a/tests/unit/test_cli_adapter.bats
+++ b/tests/unit/test_cli_adapter.bats
@@ -5,6 +5,8 @@
 # --- セットアップ ---
 
 setup() {
+    unset PERMISSION_FLAG
+
     # テスト用のtmpディレクトリ
     TEST_TMP="$(mktemp -d)"
 
@@ -126,6 +128,7 @@ YAML
 }
 
 teardown() {
+    unset PERMISSION_FLAG
     rm -rf "$TEST_TMP"
 }
 
@@ -274,6 +277,13 @@ load_adapter_with() {
     load_adapter_with "${TEST_TMP}/settings_mixed.yaml"
     result=$(build_cli_command "shogun")
     [ "$result" = "claude --model opus --dangerously-skip-permissions" ]
+}
+
+@test "build_cli_command: PERMISSION_FLAG override → claude --permission-mode auto-approved" {
+    PERMISSION_FLAG="--permission-mode auto-approved"
+    load_adapter_with "${TEST_TMP}/settings_mixed.yaml"
+    result=$(build_cli_command "shogun")
+    [ "$result" = "claude --model opus --permission-mode auto-approved" ]
 }
 
 @test "build_cli_command: codex + default model → codex --model sonnet ..." {


### PR DESCRIPTION
## 概要

本家 `yohey-w/multi-agent-shogun` の v4.6.0 を fork (`takuji-hiraoka/multi-agent-shogun`) に merge 戦略で取り込みます。

close #85

## 取り込み対象（upstream/main の3コミット）

- `20af6b5` release: v4.6.0
- `386f0e6` feat: add --auto-mode-on and --permission-mode to shutsujin_departure.sh (#124)
- `3ea7812` fix: unify report flow in instruction source files (#121)

## 競合解決（2ファイル手動解決）

| ファイル | 解決方針 |
|---------|---------|
| `CLAUDE.md` | fork の `{task_id}` 形式ファイルパスを保持（upstream の `ashigaru{N}` 形式は不採用） |
| `instructions/karo.md` | fork の「Gunshi Stall Recovery」セクションを保持 ＋ upstream の QC flow 統一（Ashigaru → Gunshi → Karo）を採用 |

## fork 独自機能の保持確認

- ✅ `scripts/context_all.sh` — 保持（upstream では削除済み）
- ✅ `scripts/ratelimit_check.sh` — ローカルTZ修正を保持
- ✅ bloom routing（動的モデルルーティング）— 保持
- ✅ QC gate（L4以上タスクの軍師QC必須）— 保持
- ✅ Karo /clear ルール — 保持

## 変更ファイル

- `shutsujin_departure.sh` — `--auto-mode-on` / `--permission-mode` オプション追加
- `instructions/karo.md` — QC flow 統一（Ashigaru → Gunshi → Karo）
- `instructions/ashigaru.md`, `instructions/gunshi.md` — report flow 統一
- `lib/cli_adapter.sh` — PERMISSION_FLAG 対応
- `CLAUDE.md` — report flow 更新
- 生成ファイル（`AGENTS.md`, `.github/copilot-instructions.md`, `agents/default/system.md`）

## テスト結果

```
bats tests/unit/: 全テスト通過（SKIP=0）
pre-commit hook（bats + ShellCheck）: 全チェック通過
```

## 注意

**PR は自動マージしないこと。殿（@takuji-hiraoka）の確認後にマージ指示をお願いします。**