### PR TITLE
🐛 fix: --auto-mode-on の permission 値を auto-approved → auto に修正

### DIFF
--- a/shutsujin_departure.sh
+++ b/shutsujin_departure.sh
@@ -149,7 +149,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --auto-mode-on)
-            PERMISSION_FLAG="--permission-mode auto-approved"
+            PERMISSION_FLAG="--permission-mode auto"
             shift
             ;;
         --permission-mode)

--- a/tests/unit/test_shutsujin_departure.bats
+++ b/tests/unit/test_shutsujin_departure.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# test_shutsujin_departure.bats — shutsujin_departure.sh オプション解析ユニットテスト
+#
+# テスト対象: shutsujin_departure.sh の --auto-mode-on / --permission-mode オプション解析
+#
+# テスト一覧:
+#   T-001: --auto-mode-on で PERMISSION_FLAG が --permission-mode auto になること
+#   T-002: --auto-mode-on で auto-approved が PERMISSION_FLAG に出現しないこと
+#   T-003: 回帰テスト — --permission-mode plan が正しく設定されること
+#   T-004: オプションなし → デフォルト --dangerously-skip-permissions になること
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+SCRIPT="$SCRIPT_DIR/shutsujin_departure.sh"
+
+setup_file() {
+    [ -f "$SCRIPT" ] || return 1
+}
+
+# オプション解析セクションを実際のスクリプトから抽出してサブシェルで実行し
+# PERMISSION_FLAG の値を返す
+parse_permission_flag() {
+    # SETUP_ONLY=false から最初の ^done$ までを抽出（オプション解析ブロック）
+    local extract
+    extract=$(awk '/^SETUP_ONLY=false/,/^done$/ { print; if (/^done$/) exit }' "$SCRIPT")
+    bash -c "${extract}; echo \"\$PERMISSION_FLAG\"" -- "$@"
+}
+
+# ─── T-001 ───
+
+@test "T-001: --auto-mode-on sets PERMISSION_FLAG to '--permission-mode auto'" {
+    result=$(parse_permission_flag --auto-mode-on)
+    [ "$result" = "--permission-mode auto" ]
+}
+
+# ─── T-002 ───
+
+@test "T-002: --auto-mode-on does not produce 'auto-approved' in PERMISSION_FLAG" {
+    result=$(parse_permission_flag --auto-mode-on)
+    [[ "$result" != *"auto-approved"* ]]
+}
+
+# ─── T-003 ───
+
+@test "T-003: --permission-mode plan sets PERMISSION_FLAG correctly (regression)" {
+    result=$(parse_permission_flag --permission-mode plan)
+    [ "$result" = "--permission-mode plan" ]
+}
+
+# ─── T-004 ───
+
+@test "T-004: no options → default PERMISSION_FLAG is '--dangerously-skip-permissions'" {
+    result=$(parse_permission_flag)
+    [ "$result" = "--dangerously-skip-permissions" ]
+}


### PR DESCRIPTION
## 概要

`shutsujin_departure.sh --auto-mode-on` 実行時に css/csm が不正なpermission modeで
エラーになっていた問題を修正。

close #87

## 変更内容

`shutsujin_departure.sh:152` の値を `auto-approved` → `auto` に修正。
Claude Code v2.1.83 で導入された正規の auto mode を起動するようになる。

## テスト

- `tests/unit/test_shutsujin_departure.bats` を新規追加（4件 SKIP=0）
- 全ユニットテスト 361件 PASS、SKIP=0
- bats + ShellCheck pre-commit フック通過済み

## 動作確認

- claude version: v2.1.126（auto mode 要件 v2.1.83 を満たす）

## 参考

- Auto mode 公式: https://claude.com/blog/auto-mode
- Permission modes Doc: https://code.claude.com/docs/en/permission-modes