### PR TITLE
🐛 fix: worktree でも .venv を自動セットアップ（cmd_172前提整備）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@
 !scripts/compact_statusline.sh
 !scripts/validate_delegation.sh
 !scripts/dashboard-viewer.py
+!scripts/setup_venv.sh
 
 # Tools (version-controlled hooks etc.)
 !tools/

--- a/Makefile
+++ b/Makefile
@@ -109,12 +109,8 @@ install-deps:
 	@if [ ! -d tests/test_helper/bats-assert ]; then \
 		git clone --depth 1 https://github.com/bats-core/bats-assert tests/test_helper/bats-assert; \
 	fi
-	@echo "3. Checking venv + PyYAML..."
-	@if [ ! -f .venv/bin/python3 ]; then \
-		echo "WARNING: .venv not found. Run: python3 -m venv .venv && .venv/bin/pip install -r requirements.txt"; \
-	elif ! .venv/bin/python3 -c "import yaml" 2>/dev/null; then \
-		echo "WARNING: PyYAML not in venv. Run: .venv/bin/pip install -r requirements.txt"; \
-	fi
+	@echo "3. Setting up .venv..."
+	@bash scripts/setup_venv.sh
 	@echo "✓ Dependencies installed"
 
 # Clean test artifacts

--- a/scripts/setup_venv.sh
+++ b/scripts/setup_venv.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# worktree を含む任意の作業ディレクトリで .venv を自動セットアップする
+set -euo pipefail
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+
+if [ -x "${PROJECT_ROOT}/.venv/bin/python3" ] && \
+   "${PROJECT_ROOT}/.venv/bin/python3" -c "import yaml" 2>/dev/null; then
+    exit 0
+fi
+
+echo "🔧 .venv を作成中: ${PROJECT_ROOT}/.venv"
+python3 -m venv "${PROJECT_ROOT}/.venv"
+
+if [ -f "${PROJECT_ROOT}/requirements.txt" ]; then
+    "${PROJECT_ROOT}/.venv/bin/pip" install -r "${PROJECT_ROOT}/requirements.txt" -q
+fi

--- a/tests/unit/test_switch_cli.bats
+++ b/tests/unit/test_switch_cli.bats
@@ -8,6 +8,11 @@ setup() {
     TEST_TMP="$(mktemp -d)"
     PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
 
+    # .venv が存在しなければ自動セットアップ（bats 直接実行時も動作するよう保証）
+    if [ ! -x "${PROJECT_ROOT}/.venv/bin/python3" ]; then
+        bash "${PROJECT_ROOT}/scripts/setup_venv.sh" >/dev/null 2>&1
+    fi
+
     # テスト用settings.yaml
     cat > "${TEST_TMP}/settings.yaml" << 'YAML'
 cli:

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -24,7 +24,16 @@ if [ ! -d "$REPO_ROOT/tests/test_helper/bats-support" ]; then
 fi
 
 # ──────────────────────────────────────────────
-# 2. ユニットテスト実行（TAP出力でSKIPも同時チェック）
+# 2. .venv セットアップ（worktree環境対応）
+# ──────────────────────────────────────────────
+echo "🔧 .venv をセットアップ中..."
+if ! bash "$REPO_ROOT/scripts/setup_venv.sh"; then
+  echo "❌ pre-commit: .venv セットアップに失敗しました"
+  exit 1
+fi
+
+# ──────────────────────────────────────────────
+# 3. ユニットテスト実行（TAP出力でSKIPも同時チェック）
 # ──────────────────────────────────────────────
 # 対象ファイル収集（agent_selfwatch除く、e2e除く）
 ALL_TESTS=()
@@ -65,7 +74,7 @@ else
 fi
 
 # ──────────────────────────────────────────────
-# 3. E2Eテスト実行（RUN_E2E=1 のときのみ）
+# 4. E2Eテスト実行（RUN_E2E=1 のときのみ）
 # ──────────────────────────────────────────────
 E2E_DIR="$REPO_ROOT/tests/e2e"
 if [ "${RUN_E2E:-0}" != "1" ]; then
@@ -108,7 +117,7 @@ else
 fi
 
 # ──────────────────────────────────────────────
-# 4. ShellCheck（lib/, scripts/）
+# 5. ShellCheck（lib/, scripts/）
 # ──────────────────────────────────────────────
 echo "🔍 pre-commit: ShellCheck 実行中..."
 if ! command -v shellcheck &>/dev/null; then


### PR DESCRIPTION
## 背景

cmd_172（feat+issue-80a-validate-task-yaml）の worktree 環境で `bats` テストが失敗するブロッカーが発生。原因は `tests/unit/test_switch_cli.bats` が `.venv/bin/python3` のパスを直接参照しており、新規 worktree 環境では `.venv` が存在しないためビルドが通らなかった。

本 PR（cmd_173）はその前提整備として、worktree 環境でも `.venv` を自動セットアップする仕組みを追加する。

## 修正方針（方針 Y: worktree 独立環境）

- `scripts/setup_venv.sh` を新設
  - `git rev-parse --show-toplevel` で worktree ルートを取得し、そのディレクトリ配下に独立した `.venv` を作成
  - 冪等設計（既存 `.venv` が正常な場合は no-op）
  - `set -euo pipefail` + shellcheck クリア
- `tools/pre-commit` に組み込み（セクション 2: .venv セットアップ）
- `tests/unit/test_switch_cli.bats` の `setup()` で `.venv` 不在時のみ自動実行
- `Makefile` の `install-deps` ターゲットに `setup_venv.sh` 呼び出しを追加

## 変更ファイル

| ファイル | 変更種別 |
|---------|---------|
| `scripts/setup_venv.sh` | 新規作成 |
| `tools/pre-commit` | セクション 2 追加 |
| `tests/unit/test_switch_cli.bats` | `setup()` に venv チェック追加 |
| `Makefile` | `install-deps` に `setup_venv.sh` 追加 |
| `.gitignore` | `!scripts/setup_venv.sh` ホワイトリスト追加 |

## 検証結果

| テスト種別 | 結果 |
|-----------|------|
| main 直下（全テスト 361 件） | ✅ PASS（SKIP=0） |
| 新規 worktree（`/tmp/wt-test-venv`）での自動セットアップ | ✅ PASS |
| `setup_venv.sh` 冪等性（2 回連続実行） | ✅ PASS（2 回目は no-op） |
| shellcheck | ✅ エラー・警告ゼロ |

## 軍師整合性チェック（subtask_173a_qc）

軍師による独立 QC を実施済み（`queue/reports/subtask_173a_qc.yaml`、status: **PASS**）。

確認項目:
- cmd_172 との並走可能性: OK（pre-commit セクション番号競合なし。cmd_172 マージ時に番号調整予定）
- 冪等性・安全性: OK
- bats `setup()` 選択の妥当性: OK
- テスト結果の妥当性: OK（軍師による再現確認済み）

## 関連

- 関連 cmd: cmd_172（feat+issue-80a-validate-task-yaml。本 PR マージ後 rebase 予定）
- Issue: #80a 関連（Issue 番号外タスクのため Closes 不記載）

## 注意

**⚠️ PR の自動マージ禁止。殿確認・マージ指示待ち。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)