### PR TITLE
✨ feat: validate_task_yaml.sh 新設（#80a check1: bloom↔assigned 整合）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@
 !scripts/switch_cli.sh
 !scripts/compact_statusline.sh
 !scripts/validate_delegation.sh
+!scripts/validate_task_yaml.sh
 !scripts/dashboard-viewer.py
 !scripts/setup_venv.sh
 

--- a/scripts/validate_task_yaml.sh
+++ b/scripts/validate_task_yaml.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # validate_task_yaml.sh — タスクYAML妥当性検証スクリプト
+# YAMLパース: .venv/bin/python3 + PyYAML（PR#91 setup_venv 前提）
 # Usage: bash scripts/validate_task_yaml.sh [file.yaml ...]
 # 引数なし: queue/tasks/*.yaml を対象
 
@@ -7,6 +8,12 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# .venv 不在時は setup_venv.sh を自動呼び出し
+VENV_PY="${REPO_ROOT}/.venv/bin/python3"
+if [ ! -x "$VENV_PY" ]; then
+    bash "${REPO_ROOT}/scripts/setup_venv.sh" >&2
+fi
 
 # 引数なし → queue/tasks/*.yaml を対象
 if [[ $# -eq 0 ]]; then
@@ -25,16 +32,27 @@ warn() {
 }
 
 # ──────────────────────────────────────────────
-# YAMLパーサ: yq 優先、なければ grep/sed フォールバック
+# YAMLパーサ: .venv/bin/python3 + PyYAML
+# .task.{field} を優先、なければ .{field} を参照（yq ".task.X // .X" と同等）
 # ──────────────────────────────────────────────
 get_field() {
   local file="$1"
   local field="$2"
-  if command -v yq &>/dev/null; then
-    yq e ".task.${field} // .${field}" "$file" 2>/dev/null | grep -v '^null$' || true
-  else
-    grep -oP "${field}:\s*\K\S+" "$file" 2>/dev/null | head -1 || true
-  fi
+  # shellcheck disable=SC2016
+  "$VENV_PY" - "$file" "$field" <<'PYEOF' 2>/dev/null || true
+import sys, yaml
+path, field = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    data = yaml.safe_load(f) or {}
+task = data.get("task") if isinstance(data.get("task"), dict) else None
+if task and field in task:
+    val = task[field]
+else:
+    val = data.get(field)
+if val is None:
+    sys.exit(0)
+print(val)
+PYEOF
 }
 
 # ──────────────────────────────────────────────

--- a/scripts/validate_task_yaml.sh
+++ b/scripts/validate_task_yaml.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# validate_task_yaml.sh — タスクYAML妥当性検証スクリプト
+# Usage: bash scripts/validate_task_yaml.sh [file.yaml ...]
+# 引数なし: queue/tasks/*.yaml を対象
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# 引数なし → queue/tasks/*.yaml を対象
+if [[ $# -eq 0 ]]; then
+  set -- "$REPO_ROOT"/queue/tasks/*.yaml
+fi
+
+error_count=0
+
+err() {
+  echo "[ERROR] $1"
+  ((error_count++)) || true
+}
+
+warn() {
+  echo "[WARN]  $1"
+}
+
+# ──────────────────────────────────────────────
+# YAMLパーサ: yq 優先、なければ grep/sed フォールバック
+# ──────────────────────────────────────────────
+get_field() {
+  local file="$1"
+  local field="$2"
+  if command -v yq &>/dev/null; then
+    yq e ".task.${field} // .${field}" "$file" 2>/dev/null | grep -v '^null$' || true
+  else
+    grep -oP "${field}:\s*\K\S+" "$file" 2>/dev/null | head -1 || true
+  fi
+}
+
+# ──────────────────────────────────────────────
+# check1: bloom_level ↔ assigned_to 整合性
+# ──────────────────────────────────────────────
+check_bloom_assigned_consistency() {
+  local file="$1"
+  local bloom assigned level
+
+  bloom="$(get_field "$file" "bloom_level")"
+  assigned="$(get_field "$file" "assigned_to")"
+
+  # bloom_level 未定義 → WARNING のみ
+  if [[ -z "$bloom" ]]; then
+    warn "${file}: bloom_level 未定義"
+    return 0
+  fi
+
+  # assigned_to 未定義 → WARNING のみ
+  if [[ -z "$assigned" ]]; then
+    warn "${file}: assigned_to 未定義"
+    return 0
+  fi
+
+  # L数字を抽出
+  level="${bloom#L}"
+
+  # L1-L4 かつ assigned_to: karo → ERROR
+  if [[ "$level" =~ ^[1-4]$ ]] && [[ "$assigned" == "karo" ]]; then
+    err "${file}: bloom_level=${bloom}, assigned_to=${assigned} — L1-L4 タスクは家老でなく足軽に委譲せよ"
+    return 0
+  fi
+
+  # L5-L6 かつ assigned_to が ashigaru* → ERROR
+  if [[ "$level" =~ ^[5-6]$ ]] && [[ "$assigned" == ashigaru* ]]; then
+    err "${file}: bloom_level=${bloom}, assigned_to=${assigned} — L5-L6 タスクは足軽でなく軍師に委譲せよ"
+    return 0
+  fi
+}
+
+# ──────────────────────────────────────────────
+# check配列（将来 check2〜5 後付け容易な構造）
+# ──────────────────────────────────────────────
+CHECKS=(check_bloom_assigned_consistency)
+
+# ──────────────────────────────────────────────
+# メイン処理
+# ──────────────────────────────────────────────
+for file in "$@"; do
+  [[ -f "$file" ]] || continue
+  for check in "${CHECKS[@]}"; do
+    "$check" "$file"
+  done
+done
+
+if [[ $error_count -gt 0 ]]; then
+  echo ""
+  echo "RESULT: FAIL — ${error_count} 件のエラーを検出"
+  exit 1
+else
+  echo "RESULT: PASS"
+  exit 0
+fi

--- a/tests/unit/test_validate_task_yaml.bats
+++ b/tests/unit/test_validate_task_yaml.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+# test_validate_task_yaml.bats — validate_task_yaml.sh unit tests
+#
+# テスト構成（全7ケース、SKIP=0厳守）:
+#   T-VTY-001: 正常系 L3 + ashigaru1 → エラー0、終了コード0
+#   T-VTY-002: 正常系 L5 + gunshi → エラー0、終了コード0
+#   T-VTY-003: 異常系 L2 + karo → エラー1、終了コード1
+#   T-VTY-004: 異常系 L6 + ashigaru3 → エラー1、終了コード1
+#   T-VTY-005: 警告系 bloom_level 未定義 → WARN、終了コード0
+#   T-VTY-006: 警告系 assigned_to 未定義 → WARN、終了コード0
+#   T-VTY-007: 複数ファイル混在 → 終了コード1、違反のみ報告
+
+load "../test_helper/bats-support/load"
+load "../test_helper/bats-assert/load"
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+VALIDATE_SCRIPT="$SCRIPT_DIR/scripts/validate_task_yaml.sh"
+
+setup() {
+    TEST_TMP="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TEST_TMP"
+}
+
+# ヘルパー: テスト用YAML作成
+make_yaml() {
+    local file="$1"
+    local bloom="$2"
+    local assigned="$3"
+    {
+        echo "task:"
+        [[ -n "$bloom" ]] && echo "  bloom_level: ${bloom}"
+        [[ -n "$assigned" ]] && echo "  assigned_to: ${assigned}"
+        echo "  status: assigned"
+    } > "$file"
+}
+
+@test "T-VTY-001: L3 + ashigaru1 → エラー0、終了コード0" {
+    make_yaml "$TEST_TMP/normal_l3.yaml" "L3" "ashigaru1"
+    run bash "$VALIDATE_SCRIPT" "$TEST_TMP/normal_l3.yaml"
+    [ "$status" -eq 0 ]
+    refute_output --partial "[ERROR]"
+    assert_output --partial "PASS"
+}
+
+@test "T-VTY-002: L5 + gunshi → エラー0、終了コード0" {
+    make_yaml "$TEST_TMP/normal_l5.yaml" "L5" "gunshi"
+    run bash "$VALIDATE_SCRIPT" "$TEST_TMP/normal_l5.yaml"
+    [ "$status" -eq 0 ]
+    refute_output --partial "[ERROR]"
+    assert_output --partial "PASS"
+}
+
+@test "T-VTY-003: L2 + karo → エラー1、終了コード1" {
+    make_yaml "$TEST_TMP/error_l2_karo.yaml" "L2" "karo"
+    run bash "$VALIDATE_SCRIPT" "$TEST_TMP/error_l2_karo.yaml"
+    [ "$status" -eq 1 ]
+    assert_output --partial "[ERROR]"
+    assert_output --partial "L1-L4 タスクは家老でなく足軽に委譲せよ"
+}
+
+@test "T-VTY-004: L6 + ashigaru3 → エラー1、終了コード1" {
+    make_yaml "$TEST_TMP/error_l6_ashigaru.yaml" "L6" "ashigaru3"
+    run bash "$VALIDATE_SCRIPT" "$TEST_TMP/error_l6_ashigaru.yaml"
+    [ "$status" -eq 1 ]
+    assert_output --partial "[ERROR]"
+    assert_output --partial "L5-L6 タスクは足軽でなく軍師に委譲せよ"
+}
+
+@test "T-VTY-005: bloom_level 未定義 → WARN、終了コード0" {
+    make_yaml "$TEST_TMP/no_bloom.yaml" "" "ashigaru2"
+    run bash "$VALIDATE_SCRIPT" "$TEST_TMP/no_bloom.yaml"
+    [ "$status" -eq 0 ]
+    assert_output --partial "[WARN]"
+    assert_output --partial "bloom_level 未定義"
+}
+
+@test "T-VTY-006: assigned_to 未定義 → WARN、終了コード0" {
+    make_yaml "$TEST_TMP/no_assigned.yaml" "L3" ""
+    run bash "$VALIDATE_SCRIPT" "$TEST_TMP/no_assigned.yaml"
+    [ "$status" -eq 0 ]
+    assert_output --partial "[WARN]"
+    assert_output --partial "assigned_to 未定義"
+}
+
+@test "T-VTY-007: 複数ファイル混在 → 終了コード1、違反のみ報告" {
+    make_yaml "$TEST_TMP/ok.yaml"    "L4" "ashigaru5"
+    make_yaml "$TEST_TMP/ng.yaml"    "L3" "karo"
+    run bash "$VALIDATE_SCRIPT" "$TEST_TMP/ok.yaml" "$TEST_TMP/ng.yaml"
+    [ "$status" -eq 1 ]
+    assert_output --partial "[ERROR]"
+    assert_output --partial "ng.yaml"
+    refute_output --partial "ok.yaml"
+}

--- a/tests/unit/test_validate_task_yaml.bats
+++ b/tests/unit/test_validate_task_yaml.bats
@@ -18,6 +18,11 @@ VALIDATE_SCRIPT="$SCRIPT_DIR/scripts/validate_task_yaml.sh"
 
 setup() {
     TEST_TMP="$(mktemp -d)"
+
+    # .venv が存在しなければ自動セットアップ（bats 直接実行時も動作するよう保証）
+    if [ ! -x "${SCRIPT_DIR}/.venv/bin/python3" ]; then
+        bash "${SCRIPT_DIR}/scripts/setup_venv.sh" >/dev/null 2>&1
+    fi
 }
 
 teardown() {

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -136,6 +136,19 @@ for dir in lib scripts; do
 done
 
 # ──────────────────────────────────────────────
+# 6. queue/tasks/*.yaml の妥当性検証（#80a check1）
+# ──────────────────────────────────────────────
+STAGED_TASK_YAMLS=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^queue/tasks/.*\.yaml$' || true)
+if [ -n "$STAGED_TASK_YAMLS" ]; then
+  echo "🔍 タスクYAML妥当性検証中..."
+  # shellcheck disable=SC2086
+  if ! bash "$REPO_ROOT/scripts/validate_task_yaml.sh" $STAGED_TASK_YAMLS; then
+    echo "❌ pre-commit: タスクYAML検証に失敗しました。"
+    FAIL=1
+  fi
+fi
+
+# ──────────────────────────────────────────────
 # 結果
 # ──────────────────────────────────────────────
 if [ "$FAIL" -eq 1 ]; then


### PR DESCRIPTION
> **[2026-05-03 追記]** 殿フィードバック「yq を優先するなら prerequisite に含めるべき」を受けて、YAMLパースを `.venv/bin/python3 + PyYAML` に統一（yq・grep/sed フォールバックを完全撤去）。commit 1129bb4 を追加。

## 概要

Epic #78 Wave 0: Issue #80a の実装。
bloom_level ↔ assigned_to の整合性を検証する `scripts/validate_task_yaml.sh` を新設。

Closes #80

## 変更内容

- `scripts/validate_task_yaml.sh` 新設（YAMLパース: .venv/bin/python3 + PyYAML）
  - check1: bloom↔assigned 整合・関数分離・check配列化（check2-5 後付け容易）
  - .venv 不在時 setup_venv.sh 自動呼び出し
- `tests/unit/test_validate_task_yaml.bats` 新設（7テスト、SKIP=0）
- `tools/pre-commit` section 6 組み込み
- `.gitignore` に !scripts/validate_task_yaml.sh 追加

## 検証結果

- bats 7/7 PASS（SKIP=0）
- pre-commit 368件 PASS、regression なし
- 軍師整合性チェック: PASS（subtask_172a_qc / subtask_175g_qc 参照）

## Epic #78 進捗

Wave 0 完了。進捗 2/6。後続: Issue #90（#80b checks 2-5）は Wave 3 で着手予定。

## 注意

PR 自動マージ禁止。殿の確認後にマージ。