### PR TITLE
📝 docs: タスクYAML 外部仕様断定文に出典/検証義務化（spec_citations 導入、#83）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@
 # Docs
 !docs/
 !docs/philosophy.md
+!docs/task_yaml_schema.md
 
 # Screenshots (masked — no secrets)
 !images/

--- a/docs/task_yaml_schema.md
+++ b/docs/task_yaml_schema.md
@@ -1,0 +1,47 @@
+# タスクYAML スキーマ定義
+
+## spec_citations フィールド
+
+外部システム仕様の断定文に対する出典・検証参照。
+
+タスクYAML内で外部システム（API / SDK / ブラウザ / OS）の挙動を断定する文言を含む場合に付与する。
+
+```yaml
+spec_citations:
+  - claim: "存在しないプロパティはエラーにならない"
+    source: "https://developers.notion.com/reference/page#property-values"
+    verified_at: "2026-04-20"
+    verified_by: cmd_XXX  # optional: 検証 cmd 番号
+  - claim: "..."
+    source: "..."  # URL または "in_task_step:N" でタスク内検証ステップ参照
+    verified_at: "..."
+```
+
+### フィールド定義
+
+| キー | 必須 | 説明 |
+|------|------|------|
+| `claim` | ✅ 必須 | 断定文の内容（仕様の主張） |
+| `source` | ✅ 必須 | 一次情報源URL、または `"in_task_step:N"`（タスク内検証ステップ参照） |
+| `verified_at` | 任意 | 検証日（YYYY-MM-DD） |
+| `verified_by` | 任意 | 検証した cmd 番号（例: `cmd_123`） |
+
+### source の記載パターン
+
+| パターン | 例 | 説明 |
+|---------|-----|------|
+| 公式ドキュメントURL | `"https://example.com/docs/api#section"` | (a) 一次情報源URL |
+| cmd参照 | `"cmd_042で実API確認済み"` | (b) 過去の検証 cmd 参照 |
+| タスク内検証 | `"in_task_step:3"` | (c) 本タスクの手順3で verify する |
+
+### ルール
+
+- 断定文が複数ある場合は entries を列挙する
+- 検証ソースのない断定文は **仮説として明示**し、`source: "in_task_step:N"` でタスク内検証ステップを参照すること
+- 既存タスクYAMLへの遡及記述義務はない（Issue #83 導入以降の新規タスクから適用）
+
+### 関連
+
+- 将軍のタスクYAML作成ルール: `instructions/shogun.md` → 外部仕様断定文の検証要件
+- 家老のタスクYAML確認義務: `instructions/karo.md` → 外部仕様断定文の検証義務
+- 自動検証（断定表現の検出）: `scripts/validate_task_yaml.sh` check4（Issue #90 / Wave 3）で実装予定

--- a/instructions/generated/codex-karo.md
+++ b/instructions/generated/codex-karo.md
@@ -70,6 +70,20 @@ task:
   timestamp: "2026-01-25T12:00:00"
 ```
 
+### 外部仕様断定文の検証義務（タスクYAML確認時）
+
+将軍から受け取ったタスクYAMLに外部仕様の断定文を見つけた場合:
+- `spec_citations` フィールドが添付されているか確認
+- (a)/(b)/(c) のいずれかが満たされているか確認
+  - (a) 一次情報源URL（公式ドキュメントの該当セクション）
+  - (b) 過去の検証 cmd 参照（例: `cmd_XXX で実API確認済み`）
+  - (c) タスク内で verify するステップ（受け入れ条件に含む）
+- いずれも欠けている場合、即座に inbox_write で将軍に問い合わせ、
+  タスクYAMLの再発行を求めること（不確かなまま実装着手しない）
+
+`spec_citations` フィールドの定義については `docs/task_yaml_schema.md` を参照。
+自動検証（断定表現の検出）は `scripts/validate_task_yaml.sh` check4（Issue #90 / Wave 3）で実装予定。
+
 ## echo_message Rule
 
 echo_message field is OPTIONAL.

--- a/instructions/generated/codex-shogun.md
+++ b/instructions/generated/codex-shogun.md
@@ -76,6 +76,21 @@ command: |
 command: "Improve karo pipeline"
 ```
 
+### 外部仕様断定文の検証要件（タスクYAML作成時）
+
+外部システム（API / SDK / ブラウザ / OS）の挙動を断定する文言を含む場合、
+以下のいずれかを **同 YAML 内に明記**せよ:
+
+(a) 一次情報源URL（公式ドキュメントの該当セクション）
+(b) 過去の検証 cmd 参照（例: `cmd_XXX で実API確認済み`）
+(c) タスク内で verify するステップ（受け入れ条件に含む）
+
+検証ソースのない断定文は **仮説として明示**し、実装中に検証するステップを
+受け入れ条件に必ず含める。
+
+`spec_citations` フィールドの定義については `docs/task_yaml_schema.md` を参照。
+自動検証（断定表現の検出）は `scripts/validate_task_yaml.sh` check4（Issue #90 / Wave 3）で実装予定。
+
 ## Critical Thinking (Lightweight — Steps 2-3)
 
 Before presenting any conclusion involving resource estimates, feasibility, or model selection to the Lord:

--- a/instructions/generated/copilot-karo.md
+++ b/instructions/generated/copilot-karo.md
@@ -70,6 +70,20 @@ task:
   timestamp: "2026-01-25T12:00:00"
 ```
 
+### 外部仕様断定文の検証義務（タスクYAML確認時）
+
+将軍から受け取ったタスクYAMLに外部仕様の断定文を見つけた場合:
+- `spec_citations` フィールドが添付されているか確認
+- (a)/(b)/(c) のいずれかが満たされているか確認
+  - (a) 一次情報源URL（公式ドキュメントの該当セクション）
+  - (b) 過去の検証 cmd 参照（例: `cmd_XXX で実API確認済み`）
+  - (c) タスク内で verify するステップ（受け入れ条件に含む）
+- いずれも欠けている場合、即座に inbox_write で将軍に問い合わせ、
+  タスクYAMLの再発行を求めること（不確かなまま実装着手しない）
+
+`spec_citations` フィールドの定義については `docs/task_yaml_schema.md` を参照。
+自動検証（断定表現の検出）は `scripts/validate_task_yaml.sh` check4（Issue #90 / Wave 3）で実装予定。
+
 ## echo_message Rule
 
 echo_message field is OPTIONAL.

--- a/instructions/generated/copilot-shogun.md
+++ b/instructions/generated/copilot-shogun.md
@@ -76,6 +76,21 @@ command: |
 command: "Improve karo pipeline"
 ```
 
+### 外部仕様断定文の検証要件（タスクYAML作成時）
+
+外部システム（API / SDK / ブラウザ / OS）の挙動を断定する文言を含む場合、
+以下のいずれかを **同 YAML 内に明記**せよ:
+
+(a) 一次情報源URL（公式ドキュメントの該当セクション）
+(b) 過去の検証 cmd 参照（例: `cmd_XXX で実API確認済み`）
+(c) タスク内で verify するステップ（受け入れ条件に含む）
+
+検証ソースのない断定文は **仮説として明示**し、実装中に検証するステップを
+受け入れ条件に必ず含める。
+
+`spec_citations` フィールドの定義については `docs/task_yaml_schema.md` を参照。
+自動検証（断定表現の検出）は `scripts/validate_task_yaml.sh` check4（Issue #90 / Wave 3）で実装予定。
+
 ## Critical Thinking (Lightweight — Steps 2-3)
 
 Before presenting any conclusion involving resource estimates, feasibility, or model selection to the Lord:

--- a/instructions/generated/karo.md
+++ b/instructions/generated/karo.md
@@ -70,6 +70,20 @@ task:
   timestamp: "2026-01-25T12:00:00"
 ```
 
+### 外部仕様断定文の検証義務（タスクYAML確認時）
+
+将軍から受け取ったタスクYAMLに外部仕様の断定文を見つけた場合:
+- `spec_citations` フィールドが添付されているか確認
+- (a)/(b)/(c) のいずれかが満たされているか確認
+  - (a) 一次情報源URL（公式ドキュメントの該当セクション）
+  - (b) 過去の検証 cmd 参照（例: `cmd_XXX で実API確認済み`）
+  - (c) タスク内で verify するステップ（受け入れ条件に含む）
+- いずれも欠けている場合、即座に inbox_write で将軍に問い合わせ、
+  タスクYAMLの再発行を求めること（不確かなまま実装着手しない）
+
+`spec_citations` フィールドの定義については `docs/task_yaml_schema.md` を参照。
+自動検証（断定表現の検出）は `scripts/validate_task_yaml.sh` check4（Issue #90 / Wave 3）で実装予定。
+
 ## echo_message Rule
 
 echo_message field is OPTIONAL.

--- a/instructions/generated/kimi-karo.md
+++ b/instructions/generated/kimi-karo.md
@@ -70,6 +70,20 @@ task:
   timestamp: "2026-01-25T12:00:00"
 ```
 
+### 外部仕様断定文の検証義務（タスクYAML確認時）
+
+将軍から受け取ったタスクYAMLに外部仕様の断定文を見つけた場合:
+- `spec_citations` フィールドが添付されているか確認
+- (a)/(b)/(c) のいずれかが満たされているか確認
+  - (a) 一次情報源URL（公式ドキュメントの該当セクション）
+  - (b) 過去の検証 cmd 参照（例: `cmd_XXX で実API確認済み`）
+  - (c) タスク内で verify するステップ（受け入れ条件に含む）
+- いずれも欠けている場合、即座に inbox_write で将軍に問い合わせ、
+  タスクYAMLの再発行を求めること（不確かなまま実装着手しない）
+
+`spec_citations` フィールドの定義については `docs/task_yaml_schema.md` を参照。
+自動検証（断定表現の検出）は `scripts/validate_task_yaml.sh` check4（Issue #90 / Wave 3）で実装予定。
+
 ## echo_message Rule
 
 echo_message field is OPTIONAL.

--- a/instructions/generated/kimi-shogun.md
+++ b/instructions/generated/kimi-shogun.md
@@ -76,6 +76,21 @@ command: |
 command: "Improve karo pipeline"
 ```
 
+### 外部仕様断定文の検証要件（タスクYAML作成時）
+
+外部システム（API / SDK / ブラウザ / OS）の挙動を断定する文言を含む場合、
+以下のいずれかを **同 YAML 内に明記**せよ:
+
+(a) 一次情報源URL（公式ドキュメントの該当セクション）
+(b) 過去の検証 cmd 参照（例: `cmd_XXX で実API確認済み`）
+(c) タスク内で verify するステップ（受け入れ条件に含む）
+
+検証ソースのない断定文は **仮説として明示**し、実装中に検証するステップを
+受け入れ条件に必ず含める。
+
+`spec_citations` フィールドの定義については `docs/task_yaml_schema.md` を参照。
+自動検証（断定表現の検出）は `scripts/validate_task_yaml.sh` check4（Issue #90 / Wave 3）で実装予定。
+
 ## Critical Thinking (Lightweight — Steps 2-3)
 
 Before presenting any conclusion involving resource estimates, feasibility, or model selection to the Lord:

--- a/instructions/generated/shogun.md
+++ b/instructions/generated/shogun.md
@@ -76,6 +76,21 @@ command: |
 command: "Improve karo pipeline"
 ```
 
+### 外部仕様断定文の検証要件（タスクYAML作成時）
+
+外部システム（API / SDK / ブラウザ / OS）の挙動を断定する文言を含む場合、
+以下のいずれかを **同 YAML 内に明記**せよ:
+
+(a) 一次情報源URL（公式ドキュメントの該当セクション）
+(b) 過去の検証 cmd 参照（例: `cmd_XXX で実API確認済み`）
+(c) タスク内で verify するステップ（受け入れ条件に含む）
+
+検証ソースのない断定文は **仮説として明示**し、実装中に検証するステップを
+受け入れ条件に必ず含める。
+
+`spec_citations` フィールドの定義については `docs/task_yaml_schema.md` を参照。
+自動検証（断定表現の検出）は `scripts/validate_task_yaml.sh` check4（Issue #90 / Wave 3）で実装予定。
+
 ## Critical Thinking (Lightweight — Steps 2-3)
 
 Before presenting any conclusion involving resource estimates, feasibility, or model selection to the Lord:

--- a/instructions/karo.md
+++ b/instructions/karo.md
@@ -466,6 +466,20 @@ task:
   timestamp: "2026-01-25T12:00:00"
 ```
 
+### 外部仕様断定文の検証義務（タスクYAML確認時）
+
+将軍から受け取ったタスクYAMLに外部仕様の断定文を見つけた場合:
+- `spec_citations` フィールドが添付されているか確認
+- (a)/(b)/(c) のいずれかが満たされているか確認
+  - (a) 一次情報源URL（公式ドキュメントの該当セクション）
+  - (b) 過去の検証 cmd 参照（例: `cmd_XXX で実API確認済み`）
+  - (c) タスク内で verify するステップ（受け入れ条件に含む）
+- いずれも欠けている場合、即座に inbox_write で将軍に問い合わせ、
+  タスクYAMLの再発行を求めること（不確かなまま実装着手しない）
+
+`spec_citations` フィールドの定義については `docs/task_yaml_schema.md` を参照。
+自動検証（断定表現の検出）は `scripts/validate_task_yaml.sh` check4（Issue #90 / Wave 3）で実装予定。
+
 ## "Wake = Full Scan" Pattern
 
 Claude Code cannot "wait". Prompt-wait = stopped.

--- a/instructions/roles/karo_role.md
+++ b/instructions/roles/karo_role.md
@@ -69,6 +69,20 @@ task:
   timestamp: "2026-01-25T12:00:00"
 ```
 
+### 外部仕様断定文の検証義務（タスクYAML確認時）
+
+将軍から受け取ったタスクYAMLに外部仕様の断定文を見つけた場合:
+- `spec_citations` フィールドが添付されているか確認
+- (a)/(b)/(c) のいずれかが満たされているか確認
+  - (a) 一次情報源URL（公式ドキュメントの該当セクション）
+  - (b) 過去の検証 cmd 参照（例: `cmd_XXX で実API確認済み`）
+  - (c) タスク内で verify するステップ（受け入れ条件に含む）
+- いずれも欠けている場合、即座に inbox_write で将軍に問い合わせ、
+  タスクYAMLの再発行を求めること（不確かなまま実装着手しない）
+
+`spec_citations` フィールドの定義については `docs/task_yaml_schema.md` を参照。
+自動検証（断定表現の検出）は `scripts/validate_task_yaml.sh` check4（Issue #90 / Wave 3）で実装予定。
+
 ## echo_message Rule
 
 echo_message field is OPTIONAL.

--- a/instructions/roles/shogun_role.md
+++ b/instructions/roles/shogun_role.md
@@ -75,6 +75,21 @@ command: |
 command: "Improve karo pipeline"
 ```
 
+### 外部仕様断定文の検証要件（タスクYAML作成時）
+
+外部システム（API / SDK / ブラウザ / OS）の挙動を断定する文言を含む場合、
+以下のいずれかを **同 YAML 内に明記**せよ:
+
+(a) 一次情報源URL（公式ドキュメントの該当セクション）
+(b) 過去の検証 cmd 参照（例: `cmd_XXX で実API確認済み`）
+(c) タスク内で verify するステップ（受け入れ条件に含む）
+
+検証ソースのない断定文は **仮説として明示**し、実装中に検証するステップを
+受け入れ条件に必ず含める。
+
+`spec_citations` フィールドの定義については `docs/task_yaml_schema.md` を参照。
+自動検証（断定表現の検出）は `scripts/validate_task_yaml.sh` check4（Issue #90 / Wave 3）で実装予定。
+
 ## Critical Thinking (Lightweight — Steps 2-3)
 
 Before presenting any conclusion involving resource estimates, feasibility, or model selection to the Lord:

--- a/instructions/shogun.md
+++ b/instructions/shogun.md
@@ -152,6 +152,21 @@ command: |
 command: "Improve karo pipeline"
 ```
 
+### 外部仕様断定文の検証要件（タスクYAML作成時）
+
+外部システム（API / SDK / ブラウザ / OS）の挙動を断定する文言を含む場合、
+以下のいずれかを **同 YAML 内に明記**せよ:
+
+(a) 一次情報源URL（公式ドキュメントの該当セクション）
+(b) 過去の検証 cmd 参照（例: `cmd_XXX で実API確認済み`）
+(c) タスク内で verify するステップ（受け入れ条件に含む）
+
+検証ソースのない断定文は **仮説として明示**し、実装中に検証するステップを
+受け入れ条件に必ず含める。
+
+`spec_citations` フィールドの定義については `docs/task_yaml_schema.md` を参照。
+自動検証（断定表現の検出）は `scripts/validate_task_yaml.sh` check4（Issue #90 / Wave 3）で実装予定。
+
 ## Immediate Delegation Principle
 
 **Delegate to Karo immediately and end your turn** so the Lord can input next command.

--- a/tests/unit/test_dynamic_model_routing.bats
+++ b/tests/unit/test_dynamic_model_routing.bats
@@ -1010,7 +1010,10 @@ print(len(doc.get('history', [])))
 
 @test "TC-FAM-001: 完全一致の足軽が存在 → ashigaru1 を返す（Spark）" {
     load_adapter_with "${TEST_TMP}/settings_mixed_cli.yaml"
-    result=$(find_agent_for_model "gpt-5.3-codex-spark")
+    # tmuxをモックして「pane未発見→最初の候補を即返す」ユニットテスト動作を保証
+    local mock_dir; mock_dir=$(mktemp -d)
+    printf '#!/bin/sh\n' > "$mock_dir/tmux" && chmod +x "$mock_dir/tmux"
+    PATH="$mock_dir:$PATH" result=$(find_agent_for_model "gpt-5.3-codex-spark")
     [ "$result" = "ashigaru1" ]
 }
 
@@ -1048,14 +1051,20 @@ print(len(doc.get('history', [])))
 
 @test "TC-FAM-007: 複数の同モデル足軽 → 番号最小を返す（ashigaru1）" {
     load_adapter_with "${TEST_TMP}/settings_all_spark.yaml"
-    result=$(find_agent_for_model "gpt-5.3-codex-spark")
+    # tmuxをモックして「pane未発見→最小番号の候補を即返す」ユニットテスト動作を保証
+    local mock_dir; mock_dir=$(mktemp -d)
+    printf '#!/bin/sh\n' > "$mock_dir/tmux" && chmod +x "$mock_dir/tmux"
+    PATH="$mock_dir:$PATH" result=$(find_agent_for_model "gpt-5.3-codex-spark")
     [ "$result" = "ashigaru1" ]
 }
 
 @test "TC-FAM-008: capability_tiersなし設定でも動作する（後方互換）" {
     load_adapter_with "${TEST_TMP}/settings_no_tiers.yaml"
     # no_tiersでもagents定義がある場合はSpark足軽を探して返す
-    result=$(find_agent_for_model "gpt-5.3-codex-spark")
+    # tmuxをモックして「pane未発見→最初の候補を即返す」ユニットテスト動作を保証
+    local mock_dir; mock_dir=$(mktemp -d)
+    printf '#!/bin/sh\n' > "$mock_dir/tmux" && chmod +x "$mock_dir/tmux"
+    PATH="$mock_dir:$PATH" result=$(find_agent_for_model "gpt-5.3-codex-spark")
     [ "$result" = "ashigaru1" ]
 }
 


### PR DESCRIPTION
## 概要

Issue #83（Epic #78 Wave 1）の実装。タスクYAMLで外部システム（API / SDK / ブラウザ / OS）の挙動を断定する文言に対して、出典・検証参照・検証ステップの義務化を導入する（`spec_citations` フィールド定義）。

Closes #83

## 変更内容

### 1. instructions/shogun.md / karo.md への新ルール追加
- **shogun.md**: 「外部仕様断定文の検証要件（タスクYAML作成時）」セクション追加
  - 断定文には (a) 一次情報源URL / (b) 過去の検証cmd参照 / (c) タスク内検証ステップ のいずれかを同YAML内に明記
  - 検証ソースなしの断定文は「仮説として明示」し受け入れ条件に検証ステップを含める
- **karo.md**: 「外部仕様断定文の検証義務（タスクYAML確認時）」セクション追加
  - `spec_citations` フィールド添付確認
  - (a)/(b)/(c) 未充足の場合は inbox_write で将軍に再発行依頼

### 2. roles/ ファイルへの等価セクション追加
- `instructions/roles/shogun_role.md`・`instructions/roles/karo_role.md` に同等セクションを追加
- `bash scripts/build_instructions.sh` で `instructions/generated/*.md` を再生成・コミット済み

### 3. spec_citations フィールド定義ドキュメント化
- `docs/task_yaml_schema.md` を新規作成（先発として1ファイルのみ）
  - 必須キー: `claim`, `source`
  - 任意キー: `verified_at`, `verified_by`
  - `source` の3パターン: (a) 公式ドキュメントURL / (b) cmd参照 / (c) `in_task_step:N`

### 4. 自動検証は Wave 3 で実装予定
- `docs/task_yaml_schema.md` 行47に明記: `validate_task_yaml.sh` の check4（Issue #90 / Wave 3）で実装予定

### 5. TC-FAM テスト修正（スコープ外・付随対応）
- `tests/unit/test_dynamic_model_routing.bats` の TC-FAM-001/007/008 を修正
- multiagent tmux セッション稼働中の環境依存バグ（既存）。pre-commit 通過のための正当な対応
- cmd_177 worktree にも同一修正が入っているが、rebase 時に both-modified 競合は発生しない（同一行の同一変更）

## Epic #78 Wave 1 進捗

| タスク | Issue | ブランチ | 状態 |
|--------|-------|----------|------|
| cmd_178 (本PR) | #83 spec_citations 導入 | feat/issue-83-spec-citations | PR作成済み |
| cmd_177 | #81 bloom 4軸目 | feat/issue-81-bloom-multi-axis | 並行作業中 |

## 並行PR（cmd_177 / Issue #81）との競合解決方針

- **本PR（cmd_178）が先発**
- `docs/task_yaml_schema.md` は both-added 競合が予想されるが、cmd_177 task YAML（行80）に「後発の場合は同ファイルへ追記する」と明記済み → **後発の cmd_177 側で rebase 統合する責務**
- TC-FAM 修正の重複は both-modified 競合なし（同一行の同一変更）

## 検証結果

- `bash tools/pre-commit`: PASS（unit 368/368 PASS, SKIP=0）
- `bash scripts/validate_task_yaml.sh`: 既存タスクYAMLに spec_citations 遡及違反なし
- `bash scripts/build_instructions.sh`: 再実行後 git status クリーン

## 軍師整合性チェック

subtask_178g QC: **PASS** （ブロッキング指摘なし）

主な確認事項:
- cmd_177 連動ルール整合 ✅
- spec_citations フィールド定義完全性 ✅
- shogun/karo 対称性 ✅
- roles/* 更新・generated/* 伝播 ✅
- build_instructions 再実行確認 ✅
- 既存タスクへの遡及違反なし ✅

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)