### PR TITLE
📝 docs: manual_verification フィールド + Rule 6 instructions 反映（#84）

### DIFF
--- a/docs/task_yaml_schema.md
+++ b/docs/task_yaml_schema.md
@@ -74,3 +74,52 @@ spec_assumptions: []
 
 ※ 自動検証（external_dependency != none / user_facing_ui: true かつ bloom_level L3 以下の検出）は
   scripts/validate_task_yaml.sh check2-3（Issue #90 / Wave 3）で実装予定。
+
+## manual_verification フィールド
+
+`user_facing_ui: true` のタスクに必須。Chrome拡張・WebアプリなどCIで完全検証できない機能の手動実機確認仕様を定義する。
+
+```yaml
+manual_verification:
+  required: true | false  # user_facing_ui: true なら強制 true
+  cases:
+    - id: MV001
+      scenario: "正常系"
+      expected: "期待する動作"
+    - id: MV002
+      scenario: "欠如系（プロパティ欠如など）"
+      expected: "適切なフォールバック"
+    - id: MV003
+      scenario: "エラー系（認証エラーなど）"
+      expected: "エラーメッセージ表示"
+  evidence_required: screenshot | log | recording
+```
+
+### フィールド定義
+
+| キー | 必須 | 説明 |
+|------|------|------|
+| `required` | ✅ 必須 | 実機確認が必要か（`user_facing_ui: true` なら強制 `true`） |
+| `cases` | ✅ 必須 | テストケース一覧（最低3件） |
+| `evidence_required` | ✅ 必須 | 証跡の種類（`screenshot` / `log` / `recording`） |
+
+各 case の必須キー:
+
+| キー | 必須 | 説明 |
+|------|------|------|
+| `id` | ✅ 必須 | ケースID（例: `MV001`） |
+| `scenario` | ✅ 必須 | テストシナリオの説明 |
+| `expected` | ✅ 必須 | 期待する動作 |
+
+### ルール
+
+- `user_facing_ui: true` のタスクは `manual_verification.required: true` 必須
+- `cases` は最低3件（正常系・欠如系・エラー系を含むことを推奨）
+- 足軽はPR bodyに `## 手動実機確認` セクションを設け、各caseの実施結果と証跡を記載する
+- 詳細ルールは `CLAUDE.md` Test Rules 項目6（実機確認ゲート）を参照
+
+### 関連
+
+- 家老の受領義務: `instructions/karo.md` → Rule 6 運用（手動実機確認の発注時義務）
+- 足軽の実施義務: `instructions/ashigaru.md` → Rule 6 運用（手動実機確認の実施義務）
+- 自動検証は `scripts/validate_task_yaml.sh` check3（Issue #90 / Wave 3）で実装予定

--- a/instructions/ashigaru.md
+++ b/instructions/ashigaru.md
@@ -328,3 +328,25 @@ After task completion, check whether to echo a battle cry:
    - If task YAML has an `echo_message` field → use that text
    - If no `echo_message` field → compose a 1-line sengoku-style battle cry summarizing what you did
    - Do NOT output any text after the echo — it must remain directly above the ❯ prompt
+
+## Rule 6 運用（手動実機確認の実施義務）
+
+`user_facing_ui: true` のタスクを実装する場合:
+
+1. タスクYAMLの `manual_verification.cases` 全件を手動実行
+2. `evidence_required` で指定された証跡（`screenshot` / `log` / `recording`）を取得
+3. PR bodyに `## 手動実機確認` セクションを設け、各caseの実施結果と証跡を添付
+
+PR bodyの書式例:
+
+```markdown
+## 手動実機確認
+
+- [x] MV001 正常系: <期待動作確認、証跡: <URL or path>>
+- [x] MV002 欠如系: <フォールバック確認、証跡: ...>
+- [x] MV003 エラー系: <エラー表示確認、証跡: ...>
+```
+
+手動実機確認なしのPR作成は禁止（CLAUDE.md Test Rules 項目6: 実機確認ゲート）。
+詳細仕様は `docs/task_yaml_schema.md` → `manual_verification フィールド` を参照。
+自動検証は `scripts/validate_task_yaml.sh` check3（Issue #90 / Wave 3）で実装予定。

--- a/instructions/generated/ashigaru.md
+++ b/instructions/generated/ashigaru.md
@@ -130,6 +130,28 @@ The `\033[1;32m` = bold green, `\033[0m` = reset. **Always use `-e` flag and the
 
 Plain text with emoji. No box/罫線.
 
+## Rule 6 運用（手動実機確認の実施義務）
+
+`user_facing_ui: true` のタスクを実装する場合:
+
+1. タスクYAMLの `manual_verification.cases` 全件を手動実行
+2. `evidence_required` で指定された証跡（`screenshot` / `log` / `recording`）を取得
+3. PR bodyに `## 手動実機確認` セクションを設け、各caseの実施結果と証跡を添付
+
+PR bodyの書式例:
+
+```markdown
+## 手動実機確認
+
+- [x] MV001 正常系: <期待動作確認、証跡: <URL or path>>
+- [x] MV002 欠如系: <フォールバック確認、証跡: ...>
+- [x] MV003 エラー系: <エラー表示確認、証跡: ...>
+```
+
+手動実機確認なしのPR作成は禁止（CLAUDE.md Test Rules 項目6: 実機確認ゲート）。
+詳細仕様は `docs/task_yaml_schema.md` → `manual_verification フィールド` を参照。
+自動検証は `scripts/validate_task_yaml.sh` check3（Issue #90 / Wave 3）で実装予定。
+
 # Communication Protocol
 
 ## Mailbox System (inbox_write.sh)

--- a/instructions/generated/codex-ashigaru.md
+++ b/instructions/generated/codex-ashigaru.md
@@ -130,6 +130,28 @@ The `\033[1;32m` = bold green, `\033[0m` = reset. **Always use `-e` flag and the
 
 Plain text with emoji. No box/罫線.
 
+## Rule 6 運用（手動実機確認の実施義務）
+
+`user_facing_ui: true` のタスクを実装する場合:
+
+1. タスクYAMLの `manual_verification.cases` 全件を手動実行
+2. `evidence_required` で指定された証跡（`screenshot` / `log` / `recording`）を取得
+3. PR bodyに `## 手動実機確認` セクションを設け、各caseの実施結果と証跡を添付
+
+PR bodyの書式例:
+
+```markdown
+## 手動実機確認
+
+- [x] MV001 正常系: <期待動作確認、証跡: <URL or path>>
+- [x] MV002 欠如系: <フォールバック確認、証跡: ...>
+- [x] MV003 エラー系: <エラー表示確認、証跡: ...>
+```
+
+手動実機確認なしのPR作成は禁止（CLAUDE.md Test Rules 項目6: 実機確認ゲート）。
+詳細仕様は `docs/task_yaml_schema.md` → `manual_verification フィールド` を参照。
+自動検証は `scripts/validate_task_yaml.sh` check3（Issue #90 / Wave 3）で実装予定。
+
 # Communication Protocol
 
 ## Mailbox System (inbox_write.sh)

--- a/instructions/generated/codex-karo.md
+++ b/instructions/generated/codex-karo.md
@@ -374,6 +374,24 @@ description: |
    - スキップすると dashboard更新・ntfy送信・日報追記を連続スキップする事故が起きる
    - 実例: cmd_060〜064で5タスク連続スキップ（2026-03-28インシデント）
 
+## Rule 6 運用（手動実機確認の発注時義務）
+
+`user_facing_ui: true` のタスクを将軍から受領した場合:
+
+1. `manual_verification` フィールドが添付されているか確認
+2. `cases` が3件以上あるか確認
+3. `evidence_required` が指定されているか確認
+4. いずれも欠けている場合、即座に `inbox_write` で将軍に問い合わせ、タスクYAMLの再発行を求めること（不完全なまま発注しない）
+
+```bash
+# 問い合わせ例
+bash scripts/inbox_write.sh shogun "cmd_XXX の manual_verification フィールドが不足。再発行を仰ぐ。" query karo
+```
+
+詳細仕様は `docs/task_yaml_schema.md` → `manual_verification フィールド` を参照。
+CLAUDE.md Test Rules 項目6（実機確認ゲート）も合わせて確認すること。
+自動検証は `scripts/validate_task_yaml.sh` check3（Issue #90 / Wave 3）で実装予定。
+
 # Communication Protocol
 
 ## Mailbox System (inbox_write.sh)

--- a/instructions/generated/copilot-ashigaru.md
+++ b/instructions/generated/copilot-ashigaru.md
@@ -130,6 +130,28 @@ The `\033[1;32m` = bold green, `\033[0m` = reset. **Always use `-e` flag and the
 
 Plain text with emoji. No box/罫線.
 
+## Rule 6 運用（手動実機確認の実施義務）
+
+`user_facing_ui: true` のタスクを実装する場合:
+
+1. タスクYAMLの `manual_verification.cases` 全件を手動実行
+2. `evidence_required` で指定された証跡（`screenshot` / `log` / `recording`）を取得
+3. PR bodyに `## 手動実機確認` セクションを設け、各caseの実施結果と証跡を添付
+
+PR bodyの書式例:
+
+```markdown
+## 手動実機確認
+
+- [x] MV001 正常系: <期待動作確認、証跡: <URL or path>>
+- [x] MV002 欠如系: <フォールバック確認、証跡: ...>
+- [x] MV003 エラー系: <エラー表示確認、証跡: ...>
+```
+
+手動実機確認なしのPR作成は禁止（CLAUDE.md Test Rules 項目6: 実機確認ゲート）。
+詳細仕様は `docs/task_yaml_schema.md` → `manual_verification フィールド` を参照。
+自動検証は `scripts/validate_task_yaml.sh` check3（Issue #90 / Wave 3）で実装予定。
+
 # Communication Protocol
 
 ## Mailbox System (inbox_write.sh)

--- a/instructions/generated/copilot-karo.md
+++ b/instructions/generated/copilot-karo.md
@@ -374,6 +374,24 @@ description: |
    - スキップすると dashboard更新・ntfy送信・日報追記を連続スキップする事故が起きる
    - 実例: cmd_060〜064で5タスク連続スキップ（2026-03-28インシデント）
 
+## Rule 6 運用（手動実機確認の発注時義務）
+
+`user_facing_ui: true` のタスクを将軍から受領した場合:
+
+1. `manual_verification` フィールドが添付されているか確認
+2. `cases` が3件以上あるか確認
+3. `evidence_required` が指定されているか確認
+4. いずれも欠けている場合、即座に `inbox_write` で将軍に問い合わせ、タスクYAMLの再発行を求めること（不完全なまま発注しない）
+
+```bash
+# 問い合わせ例
+bash scripts/inbox_write.sh shogun "cmd_XXX の manual_verification フィールドが不足。再発行を仰ぐ。" query karo
+```
+
+詳細仕様は `docs/task_yaml_schema.md` → `manual_verification フィールド` を参照。
+CLAUDE.md Test Rules 項目6（実機確認ゲート）も合わせて確認すること。
+自動検証は `scripts/validate_task_yaml.sh` check3（Issue #90 / Wave 3）で実装予定。
+
 # Communication Protocol
 
 ## Mailbox System (inbox_write.sh)

--- a/instructions/generated/karo.md
+++ b/instructions/generated/karo.md
@@ -374,6 +374,24 @@ description: |
    - スキップすると dashboard更新・ntfy送信・日報追記を連続スキップする事故が起きる
    - 実例: cmd_060〜064で5タスク連続スキップ（2026-03-28インシデント）
 
+## Rule 6 運用（手動実機確認の発注時義務）
+
+`user_facing_ui: true` のタスクを将軍から受領した場合:
+
+1. `manual_verification` フィールドが添付されているか確認
+2. `cases` が3件以上あるか確認
+3. `evidence_required` が指定されているか確認
+4. いずれも欠けている場合、即座に `inbox_write` で将軍に問い合わせ、タスクYAMLの再発行を求めること（不完全なまま発注しない）
+
+```bash
+# 問い合わせ例
+bash scripts/inbox_write.sh shogun "cmd_XXX の manual_verification フィールドが不足。再発行を仰ぐ。" query karo
+```
+
+詳細仕様は `docs/task_yaml_schema.md` → `manual_verification フィールド` を参照。
+CLAUDE.md Test Rules 項目6（実機確認ゲート）も合わせて確認すること。
+自動検証は `scripts/validate_task_yaml.sh` check3（Issue #90 / Wave 3）で実装予定。
+
 # Communication Protocol
 
 ## Mailbox System (inbox_write.sh)

--- a/instructions/generated/kimi-ashigaru.md
+++ b/instructions/generated/kimi-ashigaru.md
@@ -130,6 +130,28 @@ The `\033[1;32m` = bold green, `\033[0m` = reset. **Always use `-e` flag and the
 
 Plain text with emoji. No box/罫線.
 
+## Rule 6 運用（手動実機確認の実施義務）
+
+`user_facing_ui: true` のタスクを実装する場合:
+
+1. タスクYAMLの `manual_verification.cases` 全件を手動実行
+2. `evidence_required` で指定された証跡（`screenshot` / `log` / `recording`）を取得
+3. PR bodyに `## 手動実機確認` セクションを設け、各caseの実施結果と証跡を添付
+
+PR bodyの書式例:
+
+```markdown
+## 手動実機確認
+
+- [x] MV001 正常系: <期待動作確認、証跡: <URL or path>>
+- [x] MV002 欠如系: <フォールバック確認、証跡: ...>
+- [x] MV003 エラー系: <エラー表示確認、証跡: ...>
+```
+
+手動実機確認なしのPR作成は禁止（CLAUDE.md Test Rules 項目6: 実機確認ゲート）。
+詳細仕様は `docs/task_yaml_schema.md` → `manual_verification フィールド` を参照。
+自動検証は `scripts/validate_task_yaml.sh` check3（Issue #90 / Wave 3）で実装予定。
+
 # Communication Protocol
 
 ## Mailbox System (inbox_write.sh)

--- a/instructions/generated/kimi-karo.md
+++ b/instructions/generated/kimi-karo.md
@@ -374,6 +374,24 @@ description: |
    - スキップすると dashboard更新・ntfy送信・日報追記を連続スキップする事故が起きる
    - 実例: cmd_060〜064で5タスク連続スキップ（2026-03-28インシデント）
 
+## Rule 6 運用（手動実機確認の発注時義務）
+
+`user_facing_ui: true` のタスクを将軍から受領した場合:
+
+1. `manual_verification` フィールドが添付されているか確認
+2. `cases` が3件以上あるか確認
+3. `evidence_required` が指定されているか確認
+4. いずれも欠けている場合、即座に `inbox_write` で将軍に問い合わせ、タスクYAMLの再発行を求めること（不完全なまま発注しない）
+
+```bash
+# 問い合わせ例
+bash scripts/inbox_write.sh shogun "cmd_XXX の manual_verification フィールドが不足。再発行を仰ぐ。" query karo
+```
+
+詳細仕様は `docs/task_yaml_schema.md` → `manual_verification フィールド` を参照。
+CLAUDE.md Test Rules 項目6（実機確認ゲート）も合わせて確認すること。
+自動検証は `scripts/validate_task_yaml.sh` check3（Issue #90 / Wave 3）で実装予定。
+
 # Communication Protocol
 
 ## Mailbox System (inbox_write.sh)

--- a/instructions/karo.md
+++ b/instructions/karo.md
@@ -496,6 +496,24 @@ task:
 `spec_citations` フィールドの定義については `docs/task_yaml_schema.md` を参照。
 自動検証（断定表現の検出）は `scripts/validate_task_yaml.sh` check4（Issue #90 / Wave 3）で実装予定。
 
+### Rule 6 運用（手動実機確認の発注時義務）
+
+`user_facing_ui: true` のタスクを将軍から受領した場合:
+
+1. `manual_verification` フィールドが添付されているか確認
+2. `cases` が3件以上あるか確認
+3. `evidence_required` が指定されているか確認
+4. いずれも欠けている場合、即座に `inbox_write` で将軍に問い合わせ、タスクYAMLの再発行を求めること（不完全なまま発注しない）
+
+```bash
+# 問い合わせ例
+bash scripts/inbox_write.sh shogun "cmd_XXX の manual_verification フィールドが不足。再発行を仰ぐ。" query karo
+```
+
+詳細仕様は `docs/task_yaml_schema.md` → `manual_verification フィールド` を参照。
+CLAUDE.md Test Rules 項目6（実機確認ゲート）も合わせて確認すること。
+自動検証は `scripts/validate_task_yaml.sh` check3（Issue #90 / Wave 3）で実装予定。
+
 ## "Wake = Full Scan" Pattern
 
 Claude Code cannot "wait". Prompt-wait = stopped.

--- a/instructions/roles/ashigaru_role.md
+++ b/instructions/roles/ashigaru_role.md
@@ -128,3 +128,25 @@ Examples:
 The `\033[1;32m` = bold green, `\033[0m` = reset. **Always use `-e` flag and these color codes.**
 
 Plain text with emoji. No box/罫線.
+
+## Rule 6 運用（手動実機確認の実施義務）
+
+`user_facing_ui: true` のタスクを実装する場合:
+
+1. タスクYAMLの `manual_verification.cases` 全件を手動実行
+2. `evidence_required` で指定された証跡（`screenshot` / `log` / `recording`）を取得
+3. PR bodyに `## 手動実機確認` セクションを設け、各caseの実施結果と証跡を添付
+
+PR bodyの書式例:
+
+```markdown
+## 手動実機確認
+
+- [x] MV001 正常系: <期待動作確認、証跡: <URL or path>>
+- [x] MV002 欠如系: <フォールバック確認、証跡: ...>
+- [x] MV003 エラー系: <エラー表示確認、証跡: ...>
+```
+
+手動実機確認なしのPR作成は禁止（CLAUDE.md Test Rules 項目6: 実機確認ゲート）。
+詳細仕様は `docs/task_yaml_schema.md` → `manual_verification フィールド` を参照。
+自動検証は `scripts/validate_task_yaml.sh` check3（Issue #90 / Wave 3）で実装予定。

--- a/instructions/roles/karo_role.md
+++ b/instructions/roles/karo_role.md
@@ -372,3 +372,21 @@ description: |
    - compaction summary・/clear後・セッション継続すべての場合で必須
    - スキップすると dashboard更新・ntfy送信・日報追記を連続スキップする事故が起きる
    - 実例: cmd_060〜064で5タスク連続スキップ（2026-03-28インシデント）
+
+## Rule 6 運用（手動実機確認の発注時義務）
+
+`user_facing_ui: true` のタスクを将軍から受領した場合:
+
+1. `manual_verification` フィールドが添付されているか確認
+2. `cases` が3件以上あるか確認
+3. `evidence_required` が指定されているか確認
+4. いずれも欠けている場合、即座に `inbox_write` で将軍に問い合わせ、タスクYAMLの再発行を求めること（不完全なまま発注しない）
+
+```bash
+# 問い合わせ例
+bash scripts/inbox_write.sh shogun "cmd_XXX の manual_verification フィールドが不足。再発行を仰ぐ。" query karo
+```
+
+詳細仕様は `docs/task_yaml_schema.md` → `manual_verification フィールド` を参照。
+CLAUDE.md Test Rules 項目6（実機確認ゲート）も合わせて確認すること。
+自動検証は `scripts/validate_task_yaml.sh` check3（Issue #90 / Wave 3）で実装予定。


### PR DESCRIPTION
## 概要

Epic #78 Wave 2 - Issue #84（縮小版）対応。

Test Rule 6（実機確認ゲート）のルール文言は PR#89（cmd_168）で CLAUDE.md 追加済み。
本PRは仕様の機械検査面（YAMLフィールド定義 + instructions 運用手順）に注力した縮小スコープ。

## 変更内容

### docs/task_yaml_schema.md: manual_verification フィールド追加
```yaml
manual_verification:
  required: true | false  # user_facing_ui: true なら強制 true
  cases:
    - id: MV001
      scenario: "正常系"
      expected: "期待する動作（具体化必須）"
    - id: MV002
      scenario: "欠如系"
      expected: "適切なフォールバック"
    - id: MV003
      scenario: "エラー系"
      expected: "エラーメッセージ表示"
  evidence_required: screenshot | log | recording
```
※ テンプレの scenario/expected は実タスクで具体化すること（丸コピ不可）。
自動検証は scripts/validate_task_yaml.sh check3（Issue #90 / Wave 3）で実装予定。

### instructions/karo.md / roles/karo_role.md: Rule 6 受領義務追加
user_facing_ui: true タスク受領時に manual_verification 添付確認 → cases 3件以上確認 →
欠けている場合は将軍に問い合わせてタスクYAML再発行を求める運用手順を追加。

### instructions/ashigaru.md / roles/ashigaru_role.md: Rule 6 実施義務追加
user_facing_ui: true タスク実装時に manual_verification.cases 全件手動実行 →
evidence_required で指定された証跡取得 → PR body「## 手動実機確認」セクション記載の
運用手順を追加（書式例付き）。

### 並行PR（cmd_182 / Issue #82）との競合解決方針
本PR が先発。cmd_182（feat/issue-82-qc-trigger-multiaxis）は後発で origin/main に
rebase する際、本PR で追加した karo_role.md の Rule 6 受領義務（行376付近）を
保持しつつ cmd_182 の内容を統合すること。

## 関連
- Closes #84
- Epic #78 Wave 2（並行 1/2、もう片方は cmd_182 / Issue #82）
- 軍師整合性チェック: subtask_183g PASS（source/generated 取り違えなし確認済み）
- 縮小スコープ理由: Test Rule 6 文言は PR#89（cmd_168）で確定済み → 本PRは参照のみ

## テスト
- `bash tools/pre-commit`: 全 PASS（368/368 SKIP=0）
- `bash scripts/validate_task_yaml.sh queue/tasks/*.yaml`: 既存タスクに違反なし