### PR TITLE
✨ feat: QCトリガー多次元化（forced_conditions 追加）

### DIFF
--- a/first_setup.sh
+++ b/first_setup.sh
@@ -645,6 +645,19 @@ skill:
 logging:
   level: info  # debug | info | warn | error
   path: "$SCRIPT_DIR/logs/"
+
+# QCトリガー設定
+qc_trigger:
+  # L4以上のタスク完了時 → 軍師QC必須。QCレポートなしにdone禁止。
+  gunshi_qc_threshold: 4
+  # L1-L3 → 軍師の簡易QCで可（deliverable存在・スコープ一致のみ）
+  karo_simple_qc_range: [1, 2, 3]
+  # 以下のいずれかを含むタスクは bloom_level に関わらず軍師QC必須
+  forced_conditions:
+    - external_dependency_not_none  # 外部API/SDK 接触（external_dependency != none）
+    - user_facing_ui_true           # ブラウザ拡張/デスクトップUI（user_facing_ui: true）
+    - touches_user_setup_docs       # docs/user-setup.md 等ユーザー向け文書を編集
+    - touches_api_contract          # 外部APIコントラクトに依存する実装
 EOF
     log_success "settings.yaml を作成しました"
 else

--- a/instructions/generated/codex-gunshi.md
+++ b/instructions/generated/codex-gunshi.md
@@ -169,11 +169,25 @@ Military strategist — knowledgeable, calm, analytical.
 
 ## Autonomous Judgment Rules
 
+### 強制QC条件（bloom_level 不問）
+
+以下のいずれかを含むタスクは bloom_level に関わらず軍師QC必須:
+- external_dependency_not_none: external_dependency != none（外部API/SDK 接触）
+- user_facing_ui_true: user_facing_ui: true（ブラウザ拡張/デスクトップUI）
+- touches_user_setup_docs: docs/user-setup.md 等ユーザー向け文書を編集
+- touches_api_contract: 外部APIコントラクトに依存する実装
+
+家老が forced_conditions 該当タスクを完了報告した際、bloom_level が L3 以下でも
+必ず gunshi.yaml に QC タスクを書き込むこと。
+
+自動検証は scripts/validate_task_yaml.sh check5（#80b / Wave 3）で実装予定。
+
 **When receiving Ashigaru report** (inbox type: report_received from ashigaru):
 1. Read the report YAML from `queue/reports/ashigaru{N}_{task_id}_report.yaml`
 2. Perform QC based on task's Bloom level (see karo_role.md QC Routing)
-3. Aggregate results and forward to Karo via inbox_write with QC verdict
-4. **Do NOT contact Karo before performing QC** — Gunshi is the quality gate
+3. **Forced QC**: If the task has any forced_conditions (see above), QC is mandatory regardless of Bloom level
+4. Aggregate results and forward to Karo via inbox_write with QC verdict
+5. **Do NOT contact Karo before performing QC** — Gunshi is the quality gate
 
 **On task completion** (in this order):
 1. Self-review deliverables (re-read your output)

--- a/instructions/generated/codex-karo.md
+++ b/instructions/generated/codex-karo.md
@@ -240,6 +240,19 @@ Gunshi runs on Opus — every review consumes significant tokens. Route QC based
 
 **Why this matters**: Without this rule, 50 L2 batch tasks each triggering Gunshi review = 50× Opus calls for work that a mechanical check can validate. The token cost is unbounded and provides no quality benefit.
 
+### 強制QCトリガー（bloom_level 不問）
+
+`config/settings.yaml` `qc_trigger.forced_conditions` のいずれかに該当するタスクが
+完了した場合、bloom_level に関わらず gunshi.yaml に QC タスクを書き込むこと。
+該当判定:
+- external_dependency_not_none → タスクYAML の external_dependency != none
+- user_facing_ui_true → タスクYAML の user_facing_ui: true
+- touches_user_setup_docs → 変更ファイルに docs/user-setup.md 等を含む
+- touches_api_contract → タスクYAML の external_dependency と関連 API 仕様の言及あり
+
+自動検証は scripts/validate_task_yaml.sh check5（#80b / Wave 3）で実装予定。
+本ルールは **手動運用ルール**として家老の判断で適用する。
+
 ## SayTask Notifications
 
 Push notifications to the lord's phone via ntfy. Karo manages streaks and notifications.

--- a/instructions/generated/copilot-gunshi.md
+++ b/instructions/generated/copilot-gunshi.md
@@ -169,11 +169,25 @@ Military strategist — knowledgeable, calm, analytical.
 
 ## Autonomous Judgment Rules
 
+### 強制QC条件（bloom_level 不問）
+
+以下のいずれかを含むタスクは bloom_level に関わらず軍師QC必須:
+- external_dependency_not_none: external_dependency != none（外部API/SDK 接触）
+- user_facing_ui_true: user_facing_ui: true（ブラウザ拡張/デスクトップUI）
+- touches_user_setup_docs: docs/user-setup.md 等ユーザー向け文書を編集
+- touches_api_contract: 外部APIコントラクトに依存する実装
+
+家老が forced_conditions 該当タスクを完了報告した際、bloom_level が L3 以下でも
+必ず gunshi.yaml に QC タスクを書き込むこと。
+
+自動検証は scripts/validate_task_yaml.sh check5（#80b / Wave 3）で実装予定。
+
 **When receiving Ashigaru report** (inbox type: report_received from ashigaru):
 1. Read the report YAML from `queue/reports/ashigaru{N}_{task_id}_report.yaml`
 2. Perform QC based on task's Bloom level (see karo_role.md QC Routing)
-3. Aggregate results and forward to Karo via inbox_write with QC verdict
-4. **Do NOT contact Karo before performing QC** — Gunshi is the quality gate
+3. **Forced QC**: If the task has any forced_conditions (see above), QC is mandatory regardless of Bloom level
+4. Aggregate results and forward to Karo via inbox_write with QC verdict
+5. **Do NOT contact Karo before performing QC** — Gunshi is the quality gate
 
 **On task completion** (in this order):
 1. Self-review deliverables (re-read your output)

--- a/instructions/generated/copilot-karo.md
+++ b/instructions/generated/copilot-karo.md
@@ -240,6 +240,19 @@ Gunshi runs on Opus — every review consumes significant tokens. Route QC based
 
 **Why this matters**: Without this rule, 50 L2 batch tasks each triggering Gunshi review = 50× Opus calls for work that a mechanical check can validate. The token cost is unbounded and provides no quality benefit.
 
+### 強制QCトリガー（bloom_level 不問）
+
+`config/settings.yaml` `qc_trigger.forced_conditions` のいずれかに該当するタスクが
+完了した場合、bloom_level に関わらず gunshi.yaml に QC タスクを書き込むこと。
+該当判定:
+- external_dependency_not_none → タスクYAML の external_dependency != none
+- user_facing_ui_true → タスクYAML の user_facing_ui: true
+- touches_user_setup_docs → 変更ファイルに docs/user-setup.md 等を含む
+- touches_api_contract → タスクYAML の external_dependency と関連 API 仕様の言及あり
+
+自動検証は scripts/validate_task_yaml.sh check5（#80b / Wave 3）で実装予定。
+本ルールは **手動運用ルール**として家老の判断で適用する。
+
 ## SayTask Notifications
 
 Push notifications to the lord's phone via ntfy. Karo manages streaks and notifications.

--- a/instructions/generated/gunshi.md
+++ b/instructions/generated/gunshi.md
@@ -169,11 +169,25 @@ Military strategist — knowledgeable, calm, analytical.
 
 ## Autonomous Judgment Rules
 
+### 強制QC条件（bloom_level 不問）
+
+以下のいずれかを含むタスクは bloom_level に関わらず軍師QC必須:
+- external_dependency_not_none: external_dependency != none（外部API/SDK 接触）
+- user_facing_ui_true: user_facing_ui: true（ブラウザ拡張/デスクトップUI）
+- touches_user_setup_docs: docs/user-setup.md 等ユーザー向け文書を編集
+- touches_api_contract: 外部APIコントラクトに依存する実装
+
+家老が forced_conditions 該当タスクを完了報告した際、bloom_level が L3 以下でも
+必ず gunshi.yaml に QC タスクを書き込むこと。
+
+自動検証は scripts/validate_task_yaml.sh check5（#80b / Wave 3）で実装予定。
+
 **When receiving Ashigaru report** (inbox type: report_received from ashigaru):
 1. Read the report YAML from `queue/reports/ashigaru{N}_{task_id}_report.yaml`
 2. Perform QC based on task's Bloom level (see karo_role.md QC Routing)
-3. Aggregate results and forward to Karo via inbox_write with QC verdict
-4. **Do NOT contact Karo before performing QC** — Gunshi is the quality gate
+3. **Forced QC**: If the task has any forced_conditions (see above), QC is mandatory regardless of Bloom level
+4. Aggregate results and forward to Karo via inbox_write with QC verdict
+5. **Do NOT contact Karo before performing QC** — Gunshi is the quality gate
 
 **On task completion** (in this order):
 1. Self-review deliverables (re-read your output)

--- a/instructions/generated/karo.md
+++ b/instructions/generated/karo.md
@@ -240,6 +240,19 @@ Gunshi runs on Opus — every review consumes significant tokens. Route QC based
 
 **Why this matters**: Without this rule, 50 L2 batch tasks each triggering Gunshi review = 50× Opus calls for work that a mechanical check can validate. The token cost is unbounded and provides no quality benefit.
 
+### 強制QCトリガー（bloom_level 不問）
+
+`config/settings.yaml` `qc_trigger.forced_conditions` のいずれかに該当するタスクが
+完了した場合、bloom_level に関わらず gunshi.yaml に QC タスクを書き込むこと。
+該当判定:
+- external_dependency_not_none → タスクYAML の external_dependency != none
+- user_facing_ui_true → タスクYAML の user_facing_ui: true
+- touches_user_setup_docs → 変更ファイルに docs/user-setup.md 等を含む
+- touches_api_contract → タスクYAML の external_dependency と関連 API 仕様の言及あり
+
+自動検証は scripts/validate_task_yaml.sh check5（#80b / Wave 3）で実装予定。
+本ルールは **手動運用ルール**として家老の判断で適用する。
+
 ## SayTask Notifications
 
 Push notifications to the lord's phone via ntfy. Karo manages streaks and notifications.

--- a/instructions/generated/kimi-gunshi.md
+++ b/instructions/generated/kimi-gunshi.md
@@ -169,11 +169,25 @@ Military strategist — knowledgeable, calm, analytical.
 
 ## Autonomous Judgment Rules
 
+### 強制QC条件（bloom_level 不問）
+
+以下のいずれかを含むタスクは bloom_level に関わらず軍師QC必須:
+- external_dependency_not_none: external_dependency != none（外部API/SDK 接触）
+- user_facing_ui_true: user_facing_ui: true（ブラウザ拡張/デスクトップUI）
+- touches_user_setup_docs: docs/user-setup.md 等ユーザー向け文書を編集
+- touches_api_contract: 外部APIコントラクトに依存する実装
+
+家老が forced_conditions 該当タスクを完了報告した際、bloom_level が L3 以下でも
+必ず gunshi.yaml に QC タスクを書き込むこと。
+
+自動検証は scripts/validate_task_yaml.sh check5（#80b / Wave 3）で実装予定。
+
 **When receiving Ashigaru report** (inbox type: report_received from ashigaru):
 1. Read the report YAML from `queue/reports/ashigaru{N}_{task_id}_report.yaml`
 2. Perform QC based on task's Bloom level (see karo_role.md QC Routing)
-3. Aggregate results and forward to Karo via inbox_write with QC verdict
-4. **Do NOT contact Karo before performing QC** — Gunshi is the quality gate
+3. **Forced QC**: If the task has any forced_conditions (see above), QC is mandatory regardless of Bloom level
+4. Aggregate results and forward to Karo via inbox_write with QC verdict
+5. **Do NOT contact Karo before performing QC** — Gunshi is the quality gate
 
 **On task completion** (in this order):
 1. Self-review deliverables (re-read your output)

--- a/instructions/generated/kimi-karo.md
+++ b/instructions/generated/kimi-karo.md
@@ -240,6 +240,19 @@ Gunshi runs on Opus — every review consumes significant tokens. Route QC based
 
 **Why this matters**: Without this rule, 50 L2 batch tasks each triggering Gunshi review = 50× Opus calls for work that a mechanical check can validate. The token cost is unbounded and provides no quality benefit.
 
+### 強制QCトリガー（bloom_level 不問）
+
+`config/settings.yaml` `qc_trigger.forced_conditions` のいずれかに該当するタスクが
+完了した場合、bloom_level に関わらず gunshi.yaml に QC タスクを書き込むこと。
+該当判定:
+- external_dependency_not_none → タスクYAML の external_dependency != none
+- user_facing_ui_true → タスクYAML の user_facing_ui: true
+- touches_user_setup_docs → 変更ファイルに docs/user-setup.md 等を含む
+- touches_api_contract → タスクYAML の external_dependency と関連 API 仕様の言及あり
+
+自動検証は scripts/validate_task_yaml.sh check5（#80b / Wave 3）で実装予定。
+本ルールは **手動運用ルール**として家老の判断で適用する。
+
 ## SayTask Notifications
 
 Push notifications to the lord's phone via ntfy. Karo manages streaks and notifications.

--- a/instructions/roles/gunshi_role.md
+++ b/instructions/roles/gunshi_role.md
@@ -168,11 +168,25 @@ Military strategist — knowledgeable, calm, analytical.
 
 ## Autonomous Judgment Rules
 
+### 強制QC条件（bloom_level 不問）
+
+以下のいずれかを含むタスクは bloom_level に関わらず軍師QC必須:
+- external_dependency_not_none: external_dependency != none（外部API/SDK 接触）
+- user_facing_ui_true: user_facing_ui: true（ブラウザ拡張/デスクトップUI）
+- touches_user_setup_docs: docs/user-setup.md 等ユーザー向け文書を編集
+- touches_api_contract: 外部APIコントラクトに依存する実装
+
+家老が forced_conditions 該当タスクを完了報告した際、bloom_level が L3 以下でも
+必ず gunshi.yaml に QC タスクを書き込むこと。
+
+自動検証は scripts/validate_task_yaml.sh check5（#80b / Wave 3）で実装予定。
+
 **When receiving Ashigaru report** (inbox type: report_received from ashigaru):
 1. Read the report YAML from `queue/reports/ashigaru{N}_{task_id}_report.yaml`
 2. Perform QC based on task's Bloom level (see karo_role.md QC Routing)
-3. Aggregate results and forward to Karo via inbox_write with QC verdict
-4. **Do NOT contact Karo before performing QC** — Gunshi is the quality gate
+3. **Forced QC**: If the task has any forced_conditions (see above), QC is mandatory regardless of Bloom level
+4. Aggregate results and forward to Karo via inbox_write with QC verdict
+5. **Do NOT contact Karo before performing QC** — Gunshi is the quality gate
 
 **On task completion** (in this order):
 1. Self-review deliverables (re-read your output)

--- a/instructions/roles/karo_role.md
+++ b/instructions/roles/karo_role.md
@@ -239,6 +239,19 @@ Gunshi runs on Opus — every review consumes significant tokens. Route QC based
 
 **Why this matters**: Without this rule, 50 L2 batch tasks each triggering Gunshi review = 50× Opus calls for work that a mechanical check can validate. The token cost is unbounded and provides no quality benefit.
 
+### 強制QCトリガー（bloom_level 不問）
+
+`config/settings.yaml` `qc_trigger.forced_conditions` のいずれかに該当するタスクが
+完了した場合、bloom_level に関わらず gunshi.yaml に QC タスクを書き込むこと。
+該当判定:
+- external_dependency_not_none → タスクYAML の external_dependency != none
+- user_facing_ui_true → タスクYAML の user_facing_ui: true
+- touches_user_setup_docs → 変更ファイルに docs/user-setup.md 等を含む
+- touches_api_contract → タスクYAML の external_dependency と関連 API 仕様の言及あり
+
+自動検証は scripts/validate_task_yaml.sh check5（#80b / Wave 3）で実装予定。
+本ルールは **手動運用ルール**として家老の判断で適用する。
+
 ## SayTask Notifications
 
 Push notifications to the lord's phone via ntfy. Karo manages streaks and notifications.


### PR DESCRIPTION
## 概要

Epic #78 Wave 2（Issue #82）— QC トリガー多次元化。
bloom_level 単一軸 QC トリガーを多次元化（forced_conditions 追加）。

Closes #82

## 変更内容

### 1. first_setup.sh — settings.yaml テンプレートに qc_trigger セクション追加
```yaml
qc_trigger:
  gunshi_qc_threshold: 4
  # bloom_level に関わらず軍師QC必須な条件
  forced_conditions:
    - external_dependency_not_none   # 外部API/SDK 接触
    - user_facing_ui_true            # ブラウザ拡張/デスクトップUI
    - touches_user_setup_docs        # ユーザー向け文書を編集
    - touches_api_contract           # 外部APIコントラクト依存
```

### 2. instructions/roles/gunshi_role.md — 強制QC条件セクション追加
bloom_level 不問で QC 必須となる forced_conditions の定義を Autonomous Judgment Rules 内に追加。

### 3. instructions/roles/karo_role.md — 強制QCトリガーセクション追加
Bloom-Based QC Routing 直後に forced_conditions トリガーセクションを追加。

### 4. instructions/generated/* — build_instructions.sh で自動再生成（8 ファイル）

## 受け入れ条件

- [x] instructions/roles/gunshi_role.md に強制QC条件が明記
- [x] instructions/roles/karo_role.md にトリガールールが追加
- [x] first_setup.sh テンプレートに forced_conditions（4条件）追加
- [x] build_instructions.sh による generated/* 差分がコミットに含まれる
- [x] 「自動検証は #80b check5 で実装予定」が明記
- [x] pre-commit 全 PASS（368/368, SKIP=0）
- [x] 軍師整合性チェック PASS（subtask_182g）

## config/settings.yaml について

config/settings.yaml は .gitignore 対象（非追跡）のため、本 PR では first_setup.sh テンプレートを更新。
**既存デプロイ環境の手動対応**: config/settings.yaml の `qc_trigger` セクションに以下を追記してください:

```yaml
qc_trigger:
  gunshi_qc_threshold: 4
  forced_conditions:
    - external_dependency_not_none
    - user_facing_ui_true
    - touches_user_setup_docs
    - touches_api_contract
```

## 並行 PR（cmd_183 / Issue #84）との関係

cmd_183 PR#96（feat/issue-84-manual-verification）も instructions/roles/karo_role.md を編集。
- cmd_183（先発、PR#96 作成済み）: karo_role.md line 372 付近を追加
- 本 PR（後発）: karo_role.md line 242 付近を追加
- 行ベースで重複なし → git rebase による自動マージ可能
- 後発マージ時に rebase 実施（generated/karo.md 等 4 ファイルも build_instructions.sh 再実行で更新）

## 軍師整合性チェック

subtask_182g QC PASS（queue/reports/subtask_182g_qc.yaml）。
ブロッキング指摘なし。
