### PR TITLE
✨ feat: validate_task_yaml.sh checks 2-5 実装（#90 / Epic #78 Wave 3）

### DIFF
--- a/scripts/validate_task_yaml.sh
+++ b/scripts/validate_task_yaml.sh
@@ -45,13 +45,30 @@ path, field = sys.argv[1], sys.argv[2]
 with open(path) as f:
     data = yaml.safe_load(f) or {}
 task = data.get("task") if isinstance(data.get("task"), dict) else None
-if task and field in task:
-    val = task[field]
+
+def get_nested(d, keys):
+    for k in keys:
+        if not isinstance(d, dict):
+            return None
+        d = d.get(k)
+        if d is None:
+            return None
+    return d
+
+keys = field.split(".")
+if task:
+    val = get_nested(task, keys)
+    if val is None:
+        val = get_nested(data, keys)
 else:
-    val = data.get(field)
+    val = get_nested(data, keys)
+
 if val is None:
     sys.exit(0)
-print(val)
+if isinstance(val, bool):
+    print("true" if val else "false")
+else:
+    print(val)
 PYEOF
 }
 
@@ -94,9 +111,84 @@ check_bloom_assigned_consistency() {
 }
 
 # ──────────────────────────────────────────────
-# check配列（将来 check2〜5 後付け容易な構造）
+# check2: external_dependency 整合（ERROR）
 # ──────────────────────────────────────────────
-CHECKS=(check_bloom_assigned_consistency)
+check_external_dependency_bloom() {
+  local file="$1"
+  local ext_dep bloom level
+
+  ext_dep="$(get_field "$file" "external_dependency")"
+  [[ -z "$ext_dep" || "$ext_dep" == "none" ]] && return 0
+
+  bloom="$(get_field "$file" "bloom_level")"
+  [[ -z "$bloom" ]] && return 0
+
+  level="${bloom#L}"
+  if [[ "$level" =~ ^[1-3]$ ]]; then
+    err "${file}: external_dependency=${ext_dep}, bloom_level=${bloom} — 外部API依存タスクは bloom_level L4+ 必須"
+  fi
+}
+
+# ──────────────────────────────────────────────
+# check3: manual_verification 整合（ERROR）
+# ──────────────────────────────────────────────
+check_manual_verification() {
+  local file="$1"
+  local ui_flag mv_required
+
+  ui_flag="$(get_field "$file" "user_facing_ui")"
+  [[ "$ui_flag" != "true" ]] && return 0
+
+  mv_required="$(get_field "$file" "manual_verification.required")"
+  if [[ -z "$mv_required" || "$mv_required" == "false" ]]; then
+    err "${file}: user_facing_ui=true だが manual_verification.required が false/未設定 — UI タスクは手動検証必須"
+  fi
+}
+
+# ──────────────────────────────────────────────
+# check4: spec_citations 欠如警告（WARN）
+# ──────────────────────────────────────────────
+check_spec_citations() {
+  local file="$1"
+  local spec_assumptions spec_citations
+
+  spec_assumptions="$(get_field "$file" "spec_assumptions")"
+  [[ -z "$spec_assumptions" || "$spec_assumptions" == "[]" || "$spec_assumptions" == "{}" ]] && return 0
+
+  spec_citations="$(get_field "$file" "spec_citations")"
+  if [[ -z "$spec_citations" || "$spec_citations" == "[]" || "$spec_citations" == "{}" ]]; then
+    warn "${file}: spec_assumptions あり、spec_citations なし — 外部仕様断定文に出典を付与せよ"
+  fi
+}
+
+# ──────────────────────────────────────────────
+# check5: forced_conditions QCタスク確認（WARN）
+# ──────────────────────────────────────────────
+check_forced_conditions_qc() {
+  local file="$1"
+  local ext_dep ui_flag gunshi_yaml gunshi_status is_forced
+
+  ext_dep="$(get_field "$file" "external_dependency")"
+  ui_flag="$(get_field "$file" "user_facing_ui")"
+
+  is_forced=false
+  [[ -n "$ext_dep" && "$ext_dep" != "none" ]] && is_forced=true
+  [[ "$ui_flag" == "true" ]] && is_forced=true
+  [[ "$is_forced" == "false" ]] && return 0
+
+  gunshi_yaml="${GUNSHI_YAML_PATH:-${REPO_ROOT}/queue/tasks/gunshi.yaml}"
+  [[ ! -f "$gunshi_yaml" ]] && return 0
+
+  gunshi_status="$(get_field "$gunshi_yaml" "status")"
+  if [[ "$gunshi_status" == "idle" ]]; then
+    warn "${file}: forced_conditions 該当タスクだが軍師QCタスクが未アサイン"
+  fi
+}
+
+# ──────────────────────────────────────────────
+# check配列
+# ──────────────────────────────────────────────
+CHECKS=(check_bloom_assigned_consistency check_external_dependency_bloom check_manual_verification check_spec_citations check_forced_conditions_qc)
 
 # ──────────────────────────────────────────────
 # メイン処理

--- a/tests/unit/test_validate_task_yaml.bats
+++ b/tests/unit/test_validate_task_yaml.bats
@@ -99,3 +99,144 @@ make_yaml() {
     assert_output --partial "ng.yaml"
     refute_output --partial "ok.yaml"
 }
+
+# ──────────────────────────────────────────────
+# check2: external_dependency 整合
+# ──────────────────────────────────────────────
+
+@test "T-VTY-008: external_dep=notion_api, L3 → ERROR" {
+    cat > "$TEST_TMP/ext_dep_error.yaml" <<'YAML'
+task:
+  bloom_level: L3
+  assigned_to: ashigaru1
+  external_dependency: notion_api
+  status: assigned
+YAML
+    run bash "$VALIDATE_SCRIPT" "$TEST_TMP/ext_dep_error.yaml"
+    [ "$status" -eq 1 ]
+    assert_output --partial "[ERROR]"
+    assert_output --partial "外部API依存タスクは bloom_level L4+ 必須"
+}
+
+@test "T-VTY-009: external_dep=none, L3 → PASS" {
+    cat > "$TEST_TMP/ext_dep_none.yaml" <<'YAML'
+task:
+  bloom_level: L3
+  assigned_to: ashigaru1
+  external_dependency: none
+  status: assigned
+YAML
+    run bash "$VALIDATE_SCRIPT" "$TEST_TMP/ext_dep_none.yaml"
+    [ "$status" -eq 0 ]
+    refute_output --partial "[ERROR]"
+    assert_output --partial "PASS"
+}
+
+# ──────────────────────────────────────────────
+# check3: manual_verification 整合
+# ──────────────────────────────────────────────
+
+@test "T-VTY-010: user_facing_ui=true, manual_verification.required=false → ERROR" {
+    cat > "$TEST_TMP/mv_false.yaml" <<'YAML'
+task:
+  bloom_level: L3
+  assigned_to: ashigaru1
+  user_facing_ui: true
+  manual_verification:
+    required: false
+  status: assigned
+YAML
+    run bash "$VALIDATE_SCRIPT" "$TEST_TMP/mv_false.yaml"
+    [ "$status" -eq 1 ]
+    assert_output --partial "[ERROR]"
+    assert_output --partial "manual_verification.required が false/未設定"
+}
+
+@test "T-VTY-011: user_facing_ui=true, required=true → PASS" {
+    cat > "$TEST_TMP/mv_true.yaml" <<'YAML'
+task:
+  bloom_level: L3
+  assigned_to: ashigaru1
+  user_facing_ui: true
+  manual_verification:
+    required: true
+  status: assigned
+YAML
+    run bash "$VALIDATE_SCRIPT" "$TEST_TMP/mv_true.yaml"
+    [ "$status" -eq 0 ]
+    refute_output --partial "[ERROR]"
+    assert_output --partial "PASS"
+}
+
+# ──────────────────────────────────────────────
+# check4: spec_citations 欠如警告
+# ──────────────────────────────────────────────
+
+@test "T-VTY-012: spec_assumptions非空, spec_citations未設定 → WARN" {
+    cat > "$TEST_TMP/no_citations.yaml" <<'YAML'
+task:
+  bloom_level: L3
+  assigned_to: ashigaru1
+  spec_assumptions:
+    - "APIはv2.0以降のみ対応"
+  status: assigned
+YAML
+    run bash "$VALIDATE_SCRIPT" "$TEST_TMP/no_citations.yaml"
+    [ "$status" -eq 0 ]
+    assert_output --partial "[WARN]"
+    assert_output --partial "外部仕様断定文に出典を付与せよ"
+}
+
+@test "T-VTY-013: spec_assumptions非空, spec_citations設定 → PASS" {
+    cat > "$TEST_TMP/with_citations.yaml" <<'YAML'
+task:
+  bloom_level: L3
+  assigned_to: ashigaru1
+  spec_assumptions:
+    - "APIはv2.0以降のみ対応"
+  spec_citations:
+    - "https://example.com/api-docs"
+  status: assigned
+YAML
+    run bash "$VALIDATE_SCRIPT" "$TEST_TMP/with_citations.yaml"
+    [ "$status" -eq 0 ]
+    refute_output --partial "[ERROR]"
+    assert_output --partial "PASS"
+}
+
+# ──────────────────────────────────────────────
+# check5: forced_conditions QCタスク確認
+# ──────────────────────────────────────────────
+
+@test "T-VTY-014: forced_conditions該当, gunshi idle → WARN" {
+    cat > "$TEST_TMP/forced.yaml" <<'YAML'
+task:
+  bloom_level: L4
+  assigned_to: ashigaru1
+  external_dependency: github_api
+  status: assigned
+YAML
+    cat > "$TEST_TMP/gunshi.yaml" <<'YAML'
+task:
+  status: idle
+YAML
+    GUNSHI_YAML_PATH="$TEST_TMP/gunshi.yaml" run bash "$VALIDATE_SCRIPT" "$TEST_TMP/forced.yaml"
+    [ "$status" -eq 0 ]
+    assert_output --partial "[WARN]"
+    assert_output --partial "軍師QCタスクが未アサイン"
+}
+
+@test "T-VTY-015: forced_conditions非該当 → PASS（WARNなし）" {
+    cat > "$TEST_TMP/not_forced.yaml" <<'YAML'
+task:
+  bloom_level: L3
+  assigned_to: ashigaru1
+  external_dependency: none
+  user_facing_ui: false
+  status: assigned
+YAML
+    run bash "$VALIDATE_SCRIPT" "$TEST_TMP/not_forced.yaml"
+    [ "$status" -eq 0 ]
+    refute_output --partial "[WARN]"
+    assert_output --partial "PASS"
+}


### PR DESCRIPTION
## 概要

Epic #78 Wave 3。`scripts/validate_task_yaml.sh` に checks 2-5 を追加する。

依存 Issue（#81/#82/#83/#84）は Wave 1/2 でマージ済み。

## 変更内容

### scripts/validate_task_yaml.sh
- **check2**: `external_dependency != none` かつ `bloom_level <= L3` → ERROR
- **check3**: `user_facing_ui: true` かつ `manual_verification.required: false/未設定` → ERROR
- **check4**: `spec_assumptions` 非空 かつ `spec_citations` 未設定 → WARN
- **check5**: forced_conditions 該当（external_dependency!=none OR user_facing_ui:true）かつ `gunshi.yaml task.status=idle` → WARN
- `get_field` 関数をネストフィールド（`manual_verification.required` 等）対応に拡張

### tests/unit/test_validate_task_yaml.bats
- T-VTY-008〜015 追加（各 check 正常系・異常系）
- 既存 T-VTY-001〜007 影響なし

## テスト結果

```
bats tests/unit/test_validate_task_yaml.bats
15/15 PASS・SKIP=0
```

pre-commit 全 376 テスト PASS、ShellCheck OK。
既存タスクへの新規 ERROR なし。

## 関連

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)