### PR TITLE
fix: context_all.sh shogunペイン追加 + Opus 1M検出バグ修正

### DIFF
--- a/scripts/context_all.sh
+++ b/scripts/context_all.sh
@@ -5,23 +5,48 @@
 #   bash scripts/context_all.sh
 set -euo pipefail
 
-# ─── Collect agent panes (exclude shogun = current session) ───
+# ─── Helper: parse context usage from captured pane output ───
+# Prints "tokens_str pct_str" (e.g. "123k/200k (12%)") on success, empty on failure.
+# Supports k (kilo) and m (mega) units for Opus 4.7+ 1M token windows.
+parse_context_usage() {
+    local output="$1"
+    local usage
+    usage=$(printf '%s' "$output" \
+        | grep -oE '[0-9]+(\.[0-9]+)?[km]/[0-9]+(\.[0-9]+)?[km] tokens \([0-9]+%\)' \
+        | tail -1 || true)
+    if [[ -n "$usage" ]]; then
+        local tokens pct
+        tokens=$(printf '%s' "$usage" | grep -oE '^[0-9]+(\.[0-9]+)?[km]/[0-9]+(\.[0-9]+)?[km]')
+        pct=$(printf '%s' "$usage" | grep -oE '\([0-9]+%\)')
+        printf '%s %s' "$tokens" "$pct"
+    fi
+}
+
+# Allow sourcing for unit tests without executing main logic
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] && return 0
+
+# ─── Collect agent panes ───
 declare -A AGENT_PANES
+SHOGUN_PANE=""
 
 while IFS= read -r line; do
     pane=$(echo "$line" | awk '{print $1}')
     agent_id=$(echo "$line" | awk '{print $2}')
-    if [[ -n "$agent_id" && "$agent_id" != "shogun" ]]; then
-        AGENT_PANES["$agent_id"]="$pane"
+    if [[ -n "$agent_id" ]]; then
+        if [[ "$agent_id" == "shogun" ]]; then
+            SHOGUN_PANE="$pane"
+        else
+            AGENT_PANES["$agent_id"]="$pane"
+        fi
     fi
 done < <(tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{@agent_id}' 2>/dev/null || true)
 
-if [[ ${#AGENT_PANES[@]} -eq 0 ]]; then
+if [[ ${#AGENT_PANES[@]} -eq 0 && -z "$SHOGUN_PANE" ]]; then
     echo "エージェントペインが見つかりません（multiagentセッション未起動?）"
     exit 1
 fi
 
-# ─── Send /context to each pane ───
+# ─── Send /context to non-shogun panes only ───
 for agent in "${!AGENT_PANES[@]}"; do
     pane="${AGENT_PANES[$agent]}"
     tmux send-keys -t "$pane" '/context' Enter 2>/dev/null || true
@@ -32,25 +57,37 @@ sleep 4
 
 # ─── Capture and display ───
 printf "\n"
-printf "%-14s %-18s %-8s\n" "エージェント" "使用量" "使用率"
-printf "%-14s %-18s %-8s\n" "--------------" "------------------" "--------"
+printf "%-14s %-22s %-8s\n" "エージェント" "使用量" "使用率"
+printf "%-14s %-22s %-8s\n" "--------------" "----------------------" "--------"
 
+# shogun: capture-only (no /context sent to avoid self-interruption)
+if [[ -n "$SHOGUN_PANE" ]]; then
+    output=$(tmux capture-pane -t "$SHOGUN_PANE" -p -S -50 2>/dev/null \
+        | sed 's/\x1b\[[0-9;]*[A-Za-z]//g' \
+        || echo "")
+    result=$(parse_context_usage "$output")
+    if [[ -n "$result" ]]; then
+        tokens=$(echo "$result" | awk '{print $1}')
+        pct=$(echo "$result" | awk '{print $2}')
+        printf "%-14s %-22s %-8s\n" "shogun" "$tokens" "$pct"
+    else
+        printf "%-14s %-22s %-8s\n" "shogun" "N/A (unavailable)" ""
+    fi
+fi
+
+# other agents: /context was sent; parse failure means still busy
 for agent in $(echo "${!AGENT_PANES[@]}" | tr ' ' '\n' | sort); do
     pane="${AGENT_PANES[$agent]}"
-    # Capture last 50 lines, strip all ANSI escape sequences
     output=$(tmux capture-pane -t "$pane" -p -S -50 2>/dev/null \
         | sed 's/\x1b\[[0-9;]*[A-Za-z]//g' \
         || echo "")
-
-    # Extract "XXk/200k tokens (YY%)" pattern
-    usage=$(echo "$output" | grep -oE '[0-9]+(\.[0-9]+)?k/[0-9]+k tokens \([0-9]+%\)' | tail -1 || true)
-
-    if [[ -n "$usage" ]]; then
-        tokens=$(echo "$usage" | grep -oE '^[0-9]+(\.[0-9]+)?k/[0-9]+k')
-        pct=$(echo "$usage" | grep -oE '\([0-9]+%\)')
-        printf "%-14s %-18s %-8s\n" "$agent" "$tokens" "$pct"
+    result=$(parse_context_usage "$output")
+    if [[ -n "$result" ]]; then
+        tokens=$(echo "$result" | awk '{print $1}')
+        pct=$(echo "$result" | awk '{print $2}')
+        printf "%-14s %-22s %-8s\n" "$agent" "$tokens" "$pct"
     else
-        printf "%-14s %-18s %-8s\n" "$agent" "N/A (busy?)" ""
+        printf "%-14s %-22s %-8s\n" "$agent" "N/A (busy?)" ""
     fi
 done
 

--- a/tests/unit/test_context_all.bats
+++ b/tests/unit/test_context_all.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# test_context_all.bats — scripts/context_all.sh parse_context_usage() ユニットテスト
+# Issue #76 (shogun表示) / Issue #95 (Opus 1M検出バグ) の修正検証
+
+setup() {
+    PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    # Source only (main logic is guarded by BASH_SOURCE check)
+    # shellcheck source=/dev/null
+    source "$PROJECT_ROOT/scripts/context_all.sh"
+}
+
+# ─── parse_context_usage: 標準 k/k 形式 ───
+
+@test "parse: k/k 形式を正しくパースする" {
+    local output="Tokens: 123k/200k tokens (61%)"
+    result=$(parse_context_usage "$output")
+    [[ "$result" == "123k/200k (61%)" ]]
+}
+
+@test "parse: 小数点付き k/k 形式をパースする" {
+    local output="Context: 1.5k/200k tokens (1%)"
+    result=$(parse_context_usage "$output")
+    [[ "$result" == "1.5k/200k (1%)" ]]
+}
+
+# ─── parse_context_usage: k/m 形式（Opus 4.7 / 1M window） ───
+
+@test "parse: k/m 形式（Opus 1M）を正しくパースする" {
+    local output="Context window: 50k/1m tokens (5%)"
+    result=$(parse_context_usage "$output")
+    [[ "$result" == "50k/1m (5%)" ]]
+}
+
+@test "parse: 小数点付き k/m 形式をパースする" {
+    local output="Used: 1.2k/1m tokens (0%)"
+    result=$(parse_context_usage "$output")
+    [[ "$result" == "1.2k/1m (0%)" ]]
+}
+
+@test "parse: m/m 形式をパースする" {
+    local output="Context: 0.5m/1m tokens (50%)"
+    result=$(parse_context_usage "$output")
+    [[ "$result" == "0.5m/1m (50%)" ]]
+}
+
+# ─── parse_context_usage: マッチしない入力 ───
+
+@test "parse: 空文字列は空を返す" {
+    result=$(parse_context_usage "")
+    [[ -z "$result" ]]
+}
+
+@test "parse: コンテキスト情報のない出力は空を返す" {
+    local output="claude is thinking..."
+    result=$(parse_context_usage "$output")
+    [[ -z "$result" ]]
+}
+
+@test "parse: 旧 k のみ形式（k/k 以外）は空を返す" {
+    local output="123k/200 tokens (61%)"
+    result=$(parse_context_usage "$output")
+    [[ -z "$result" ]]
+}
+
+# ─── parse_context_usage: 複数行から最後の値を取得 ───
+
+@test "parse: 複数行ある場合は最後のエントリを返す" {
+    local output
+    output="$(printf '10k/200k tokens (5%%)\n100k/200k tokens (50%%)')"
+    result=$(parse_context_usage "$output")
+    [[ "$result" == "100k/200k (50%)" ]]
+}
+
+# ─── スクリプトがソース可能かつシンタックスエラーなし ───
+
+@test "script: bash -n でシンタックスエラーなし" {
+    run bash -n "$PROJECT_ROOT/scripts/context_all.sh"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## 概要

- **Issue #76**: shogunペインを一覧に追加（capture-onlyで自セッション干渉なし）
- **Issue #95**: Opus 4.7 / 1Mトークンウィンドウの検出バグ修正

## 変更内容

### scripts/context_all.sh

- `parse_context_usage()` 関数を分離（ユニットテスト可能な構造に）
- shogunペインを `tmux capture-pane` で取得（`/context` 送信なし）
  - 取得できない場合は `N/A (unavailable)` と表示（busy? とは区別）
- パース正規表現を `[0-9.]+[km]/[0-9.]+[km]` 形式に拡張
  - `123k/200k` (既存) と `50k/1m` (Opus 4.7) の両形式に対応
- スクリプトをsource可能な構造に変更（`BASH_SOURCE` ガード追加）

### tests/unit/test_context_all.bats（新規）

- `parse_context_usage()` の10件のユニットテスト（全Pass・SKIP=0）

## 受け入れ条件

- [x] `scripts/context_all.sh` が shogunペインを一覧に表示する
- [x] gunshi（Opus 4.7 / 1M tokens）の使用率が `N/A` でなく数値で表示される
- [x] テストが追加されている（SKIP=0）
- [x] PR が作成されている（Closes #76, Closes #95 明記）

Closes #76
Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)