### PR TITLE
✨ feat: worktree-healthcheck スキル新設（worktree作成直後の検証フロー実行）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,10 @@
 !skills/shogun-screenshot/scripts/*.py
 !skills/spec-doc-parallel/
 !skills/spec-doc-parallel/SKILL.md
+!skills/worktree-healthcheck/
+!skills/worktree-healthcheck/SKILL.md
+!skills/worktree-healthcheck/scripts/
+!skills/worktree-healthcheck/scripts/*.sh
 
 # Python venv (explicit deny — whitelist patterns like LICENSE leak through !*/)
 .venv/

--- a/skills/worktree-healthcheck/SKILL.md
+++ b/skills/worktree-healthcheck/SKILL.md
@@ -4,6 +4,7 @@ description: |
   worktree作成直後にプロジェクトの既存検証フロー（テスト/lint/build/pre-commit等）を
   1回流して「環境起因 Fail」と「仕様起因 Fail」を切り分ける診断スキル。
   npm/uv/poetry/cargo/go/bats/Makefile/pre-commit 等10種のプロジェクト形式を自動検出。
+  検証前に .env/local 等の機密設定ファイルを main worktree から symlink する Pre-flight も実行。
   「worktreeヘルスチェック」「wt検証」「healthcheck」「環境確認」「worktree確認」で起動。
   Do NOT use for: 通常のテスト実行（npm test 等を直接呼べばよい）、CI設定変更、本番環境チェック。
 argument-hint: "[worktree_path]"
@@ -31,7 +32,47 @@ worktree作成直後に既存の検証フロー（pre-commit/test/build等）を
 - CI設定・ワークフロー変更
 - 本番環境のヘルスチェック
 
-## 3. Detection Patterns（10件、priority順）
+## 3. Pre-flight: .env Symlink
+
+### 概要
+worktree内に機密設定ファイル（.env/local 等）が存在しない場合、
+main worktreeから symlink を作成してTest Rule 5（外部APIテスト必須）を充足する。
+
+### 検出条件
+以下を全て満たす場合に実行:
+- 現在のディレクトリが git worktree list の main worktree でない
+- main worktree の .env/local（または .env.local, .env.test）が存在する
+- 現在の worktree に同ファイルが存在しない
+
+### 実行手順
+```bash
+MAIN_WT=$(git worktree list | head -1 | awk '{print $1}')
+WTS=(
+  ".env/local"
+  ".env.local"
+  ".env.test"
+)
+for f in "${WTS[@]}"; do
+  if [ -f "$MAIN_WT/$f" ] && [ ! -e "$f" ]; then
+    mkdir -p "$(dirname "$f")"
+    ln -sf "$MAIN_WT/$f" "$f"
+    echo "[env-symlink] created: $f → $MAIN_WT/$f"
+  fi
+done
+```
+
+### 失敗時の振る舞い
+- main worktree が見つからない → skip (警告のみ)
+- symlink 先が既に存在する → skip (already_exists 表示)
+- permission denied → 警告を出力して続行 (healthcheck は止めない)
+
+### 出力例
+```
+[env-symlink] main worktree: /home/user/work/my-project
+[env-symlink] created: .env/local → /home/user/work/my-project/.env/local
+```
+
+## 4. Detection Patterns（10件、priority順）
 
 | priority | 検出ファイル/条件 | 判定条件 | 実行コマンド | timeout |
 |---|---|---|---|---|
@@ -48,14 +89,14 @@ worktree作成直後に既存の検証フロー（pre-commit/test/build等）を
 
 **No match**: SKIP + suggestion 出力（README / CONTRIBUTING / .github/workflows 参照を促す）
 
-## 4. Decision Rule（複数該当時の優先順位）
+## 5. Decision Rule（複数該当時の優先順位）
 
 priority 順で**最初にマッチしたパターンを採用**。より具体的・網羅的なものを優先。
 
 **例**: my-save2notion worktree で tools/pre-commit と package.json 両方存在する場合
 → priority 1 (tools/pre-commit) を採用。内部で validate を呼び出しているため1コマンドで完結。
 
-## 5. Output Format（Worktree Healthcheck Result 形式）
+## 6. Output Format（Worktree Healthcheck Result 形式）
 
 ```
 ## Worktree Healthcheck Result
@@ -80,7 +121,7 @@ priority 順で**最初にマッチしたパターンを採用**。より具体�
 <失敗起因の切り分け示唆>
 ```
 
-## 6. Failure Diagnostic（失敗時切り分け指針）
+## 7. Failure Diagnostic（失敗時切り分け指針）
 
 | カテゴリ | 検出キーワード | 推奨アクション |
 |---|---|---|
@@ -89,7 +130,21 @@ priority 順で**最初にマッチしたパターンを採用**。より具体�
 | ツール未インストール | permission denied, command not found, exec format error | 必要ツール導入（pre-commit/uv/poetry/cargo/go/bats）。chmod +x tools/pre-commit 確認 |
 | タイムアウト | duration > timeout_seconds, SIGTERM | 大規模テストスイートの可能性。家老に timeout 延長を依頼 |
 
-## 7. Examples（実行例）
+## 8. Examples（実行例）
+
+### Pre-flight 例（my-save2notion issue-102-create-db worktree）
+
+```
+[env-symlink] main worktree: /home/takuji.hiraoka/work/my-save2notion
+[env-symlink] created: .env/local → /home/takuji.hiraoka/work/my-save2notion/.env/local
+[env-symlink] not found in main: .env.local (skip)
+[env-symlink] not found in main: .env.test (skip)
+```
+
+```
+$ ls -la .env/local
+lrwxrwxrwx 1 user user 51 May  7 12:34 .env/local -> /home/takuji.hiraoka/work/my-save2notion/.env/local
+```
 
 ### PASS 例（multi-agent-shogun）
 
@@ -136,7 +191,7 @@ ERR! ELIFECYCLE
 - suggestion: README.md / CONTRIBUTING.md の "Test" セクション参照
 ```
 
-## 8. Guidelines（軍師・家老が判断する原則）
+## 9. Guidelines（軍師・家老が判断する原則）
 
 - worktree作成直後の**1回限定**（毎回流すのは過剰）
 - timeout 内に終わらない場合は家老に延長依頼

--- a/skills/worktree-healthcheck/SKILL.md
+++ b/skills/worktree-healthcheck/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: worktree-healthcheck
+description: |
+  worktree作成直後にプロジェクトの既存検証フロー（テスト/lint/build/pre-commit等）を
+  1回流して「環境起因 Fail」と「仕様起因 Fail」を切り分ける診断スキル。
+  npm/uv/poetry/cargo/go/bats/Makefile/pre-commit 等10種のプロジェクト形式を自動検出。
+  「worktreeヘルスチェック」「wt検証」「healthcheck」「環境確認」「worktree確認」で起動。
+  Do NOT use for: 通常のテスト実行（npm test 等を直接呼べばよい）、CI設定変更、本番環境チェック。
+argument-hint: "[worktree_path]"
+---
+
+# /worktree-healthcheck — worktree作成直後の検証フロー実行
+
+## 1. Overview — スキルの目的と適用範囲
+
+worktree作成直後に既存の検証フロー（pre-commit/test/build等）を**1回**流して、
+後続作業で発生する Fail が「環境起因」なのか「仕様起因（実装上の問題）」なのかを切り分ける診断スキル。
+
+**適用範囲**: WSL2/Linux/Mac 上の git worktree。Bash が使える環境前提。
+
+## 2. When to Use（発火条件・非発火条件）
+
+**発火条件**:
+- `git worktree add` した直後（足軽タスクをアサインする前）
+- 「環境起因か仕様起因か切り分けたい」とき
+- pre-commit が失敗したが原因が不明なとき
+- 「worktreeヘルスチェック」「wt検証」「healthcheck」「環境確認」と言われたとき
+
+**Do NOT use for**:
+- 通常のテスト実行（`npm test` 等を直接呼べばよい）
+- CI設定・ワークフロー変更
+- 本番環境のヘルスチェック
+
+## 3. Detection Patterns（10件、priority順）
+
+| priority | 検出ファイル/条件 | 判定条件 | 実行コマンド | timeout |
+|---|---|---|---|---|
+| 1 | tools/pre-commit | `test -x tools/pre-commit` | `./tools/pre-commit` | 600s |
+| 2 | .pre-commit-config.yaml | `test -f` + `command -v pre-commit` | `pre-commit run --all-files` | 600s |
+| 3 | package.json (scripts.validate) | `jq -e '.scripts.validate'` | `npm install --silent && npm run validate` | 900s |
+| 4 | package.json (scripts.test) | `jq -e '.scripts.test'` | `npm install --silent && npm test` | 600s |
+| 5 | pyproject.toml + uv.lock | `test -f` 両方 | `uv sync && uv run pytest` | 900s |
+| 6 | pyproject.toml + poetry.lock | `test -f` 両方 | `poetry install && poetry run pytest` | 900s |
+| 7 | Cargo.toml | `test -f Cargo.toml` | `cargo check && cargo test` | 1200s |
+| 8 | go.mod | `test -f go.mod` | `go mod download && go test ./...` | 600s |
+| 9 | Makefile (test target) | `grep -qE '^(test\|check):'` | `make test` | 600s |
+| 10 | tests/*.bats | `ls tests/*.bats` | `bats tests/` | 600s |
+
+**No match**: SKIP + suggestion 出力（README / CONTRIBUTING / .github/workflows 参照を促す）
+
+## 4. Decision Rule（複数該当時の優先順位）
+
+priority 順で**最初にマッチしたパターンを採用**。より具体的・網羅的なものを優先。
+
+**例**: my-save2notion worktree で tools/pre-commit と package.json 両方存在する場合
+→ priority 1 (tools/pre-commit) を採用。内部で validate を呼び出しているため1コマンドで完結。
+
+## 5. Output Format（Worktree Healthcheck Result 形式）
+
+```
+## Worktree Healthcheck Result
+
+- **worktree path**: <絶対パス>
+- **branch**: <現在のブランチ名>
+- **detected pattern**: <ファイル> (priority N)
+- **executed command**: `<実行コマンド>`
+- **duration**: <秒数>s
+- **result**: ✅ PASS / ❌ FAIL / ⚠️ SKIP
+```
+
+失敗時のみ追記:
+
+```
+### Output (last 20 lines)
+\`\`\`
+<stdout/stderr の最後20行>
+\`\`\`
+
+### Diagnostic
+<失敗起因の切り分け示唆>
+```
+
+## 6. Failure Diagnostic（失敗時切り分け指針）
+
+| カテゴリ | 検出キーワード | 推奨アクション |
+|---|---|---|
+| 環境起因（worktree設定不備） | node_modules, Cannot find module, biome: not found, eslint: not found, vitest: not found | npm install / uv sync 等の依存解決を再実行。.env ファイル確認 |
+| ベース起因（main ブランチに同問題） | TS2304, TS2345, assertion fail（複数件） | main ブランチで同 healthcheck 実行して比較。main で PASS → 自 branch の実装問題 |
+| ツール未インストール | permission denied, command not found, exec format error | 必要ツール導入（pre-commit/uv/poetry/cargo/go/bats）。chmod +x tools/pre-commit 確認 |
+| タイムアウト | duration > timeout_seconds, SIGTERM | 大規模テストスイートの可能性。家老に timeout 延長を依頼 |
+
+## 7. Examples（実行例）
+
+### PASS 例（multi-agent-shogun）
+
+```
+## Worktree Healthcheck Result
+- worktree path: /home/takuji.hiraoka/work/multi-agent-shogun
+- branch: feat/skill-worktree-healthcheck
+- detected pattern: tools/pre-commit (priority 1)
+- executed command: `./tools/pre-commit`
+- duration: 47s
+- result: ✅ PASS
+```
+
+### FAIL 例（npm 環境起因）
+
+```
+## Worktree Healthcheck Result
+- worktree path: /home/takuji.hiraoka/work/my-save2notion-wt/issue-XXX
+- branch: feat/issue-XXX
+- detected pattern: package.json scripts.validate (priority 3)
+- executed command: `npm install --silent && npm run validate`
+- duration: 32s
+- result: ❌ FAIL
+
+### Output (last 20 lines)
+\`\`\`
+sh: 1: biome: not found
+ERR! ELIFECYCLE
+\`\`\`
+
+### Diagnostic
+環境起因の可能性が高い: node_modules 未インストール、または devDependencies が不足。
+`npm install` 再実行を推奨。
+```
+
+### SKIP 例（空ディレクトリ）
+
+```
+## Worktree Healthcheck Result
+- worktree path: /tmp/empty-dir
+- branch: (detached)
+- result: ⚠️ SKIP
+- reason: 検出可能なテストフレームワークが見つかりません
+- suggestion: README.md / CONTRIBUTING.md の "Test" セクション参照
+```
+
+## 8. Guidelines（軍師・家老が判断する原則）
+
+- worktree作成直後の**1回限定**（毎回流すのは過剰）
+- timeout 内に終わらない場合は家老に延長依頼
+- main ブランチでも同じ FAIL なら自 branch の問題ではない（ベース起因）
+- WSL2 の場合、Windows 側の実行ファイルを参照していないか確認
+
+## Implementation Note
+
+本スキルの実行ロジックは `skills/worktree-healthcheck/scripts/healthcheck.sh` で実装される。
+引数なしで実行すると現在ディレクトリを対象とし、パスを渡すと指定 worktree を対象とする。
+
+```bash
+# 現在ディレクトリ
+bash skills/worktree-healthcheck/scripts/healthcheck.sh
+
+# 別 worktree を指定
+bash skills/worktree-healthcheck/scripts/healthcheck.sh /path/to/worktree
+```

--- a/skills/worktree-healthcheck/SKILL.md
+++ b/skills/worktree-healthcheck/SKILL.md
@@ -45,20 +45,57 @@ main worktreeから symlink を作成してTest Rule 5（外部APIテスト必�
 - 現在の worktree に同ファイルが存在しない
 
 ### 実行手順
+healthcheck.sh の冒頭で `pre_flight_env_symlink()` が自動実行される:
+
 ```bash
-MAIN_WT=$(git worktree list | head -1 | awk '{print $1}')
-WTS=(
-  ".env/local"
-  ".env.local"
-  ".env.test"
-)
-for f in "${WTS[@]}"; do
-  if [ -f "$MAIN_WT/$f" ] && [ ! -e "$f" ]; then
-    mkdir -p "$(dirname "$f")"
-    ln -sf "$MAIN_WT/$f" "$f"
-    echo "[env-symlink] created: $f → $MAIN_WT/$f"
+pre_flight_env_symlink() {
+  local main_wt
+  main_wt=$(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2; exit}')
+
+  # main worktree取得失敗 / 自身が main worktree → skip
+  if [[ -z "$main_wt" ]] || [[ "$main_wt" == "$WORKTREE_PATH" ]]; then
+    return 0
   fi
-done
+
+  local env_files=(".env/local" ".env.local" ".env.test")
+  local symlink_count=0
+  local skip_count=0
+
+  for f in "${env_files[@]}"; do
+    local src="$main_wt/$f"
+    local dst="$WORKTREE_PATH/$f"
+
+    if [[ ! -f "$src" ]] && [[ ! -L "$src" ]]; then
+      continue  # main側に存在しない → skip
+    fi
+
+    if [[ -e "$dst" ]] || [[ -L "$dst" ]]; then
+      ((skip_count++))
+      echo "[env-symlink] already_exists: $f"
+      continue
+    fi
+
+    local dst_dir
+    dst_dir=$(dirname "$dst")
+    if [[ ! -d "$dst_dir" ]]; then
+      mkdir -p "$dst_dir" 2>/dev/null || {
+        echo "[env-symlink] WARN: mkdir failed for $dst_dir, skipping $f"
+        continue
+      }
+    fi
+
+    if ln -sf "$src" "$dst" 2>/dev/null; then
+      ((symlink_count++))
+      echo "[env-symlink] created: $f → $src"
+    else
+      echo "[env-symlink] WARN: symlink failed for $f"
+    fi
+  done
+
+  if [[ $symlink_count -eq 0 ]] && [[ $skip_count -eq 0 ]]; then
+    echo "[env-symlink] no env files in main worktree to link"
+  fi
+}
 ```
 
 ### 失敗時の振る舞い
@@ -68,7 +105,8 @@ done
 
 ### 出力例
 ```
-[env-symlink] main worktree: /home/user/work/my-project
+## Pre-flight: .env Symlink
+
 [env-symlink] created: .env/local → /home/user/work/my-project/.env/local
 ```
 
@@ -135,10 +173,9 @@ priority 順で**最初にマッチしたパターンを採用**。より具体�
 ### Pre-flight 例（my-save2notion issue-102-create-db worktree）
 
 ```
-[env-symlink] main worktree: /home/takuji.hiraoka/work/my-save2notion
+## Pre-flight: .env Symlink
+
 [env-symlink] created: .env/local → /home/takuji.hiraoka/work/my-save2notion/.env/local
-[env-symlink] not found in main: .env.local (skip)
-[env-symlink] not found in main: .env.test (skip)
 ```
 
 ```

--- a/skills/worktree-healthcheck/SKILL.md
+++ b/skills/worktree-healthcheck/SKILL.md
@@ -70,7 +70,7 @@ pre_flight_env_symlink() {
     fi
 
     if [[ -e "$dst" ]] || [[ -L "$dst" ]]; then
-      ((skip_count++))
+      skip_count=$((skip_count + 1))
       echo "[env-symlink] already_exists: $f"
       continue
     fi
@@ -85,7 +85,7 @@ pre_flight_env_symlink() {
     fi
 
     if ln -sf "$src" "$dst" 2>/dev/null; then
-      ((symlink_count++))
+      symlink_count=$((symlink_count + 1))
       echo "[env-symlink] created: $f → $src"
     else
       echo "[env-symlink] WARN: symlink failed for $f"

--- a/skills/worktree-healthcheck/scripts/healthcheck.sh
+++ b/skills/worktree-healthcheck/scripts/healthcheck.sh
@@ -19,6 +19,59 @@ PATTERN=""
 CMD=""
 TIMEOUT=600
 
+pre_flight_env_symlink() {
+  local main_wt
+  main_wt=$(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2; exit}')
+
+  if [[ -z "$main_wt" ]] || [[ "$main_wt" == "$WORKTREE_PATH" ]]; then
+    return 0
+  fi
+
+  local env_files=(".env/local" ".env.local" ".env.test")
+  local symlink_count=0
+  local skip_count=0
+
+  for f in "${env_files[@]}"; do
+    local src="$main_wt/$f"
+    local dst="$WORKTREE_PATH/$f"
+
+    if [[ ! -f "$src" ]] && [[ ! -L "$src" ]]; then
+      continue
+    fi
+
+    if [[ -e "$dst" ]] || [[ -L "$dst" ]]; then
+      ((skip_count++))
+      echo "[env-symlink] already_exists: $f"
+      continue
+    fi
+
+    local dst_dir
+    dst_dir=$(dirname "$dst")
+    if [[ ! -d "$dst_dir" ]]; then
+      mkdir -p "$dst_dir" 2>/dev/null || {
+        echo "[env-symlink] WARN: mkdir failed for $dst_dir, skipping $f"
+        continue
+      }
+    fi
+
+    if ln -sf "$src" "$dst" 2>/dev/null; then
+      ((symlink_count++))
+      echo "[env-symlink] created: $f → $src"
+    else
+      echo "[env-symlink] WARN: symlink failed for $f"
+    fi
+  done
+
+  if [[ $symlink_count -eq 0 ]] && [[ $skip_count -eq 0 ]]; then
+    echo "[env-symlink] no env files in main worktree to link"
+  fi
+}
+
+echo "## Pre-flight: .env Symlink"
+echo ""
+pre_flight_env_symlink
+echo ""
+
 # 検出ロジック (priority 1-10)
 if [[ -x tools/pre-commit ]]; then
   PATTERN="tools/pre-commit (priority 1)"

--- a/skills/worktree-healthcheck/scripts/healthcheck.sh
+++ b/skills/worktree-healthcheck/scripts/healthcheck.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# worktree-healthcheck: プロジェクト形式を自動検出して検証フローを実行する
+# Usage: healthcheck.sh [worktree_path]
+
+set -euo pipefail
+
+WORKTREE_PATH="${1:-$(pwd)}"
+
+if [[ ! -d "$WORKTREE_PATH" ]]; then
+  echo "ERROR: ディレクトリが存在しません: $WORKTREE_PATH" >&2
+  exit 1
+fi
+
+cd "$WORKTREE_PATH"
+
+BRANCH=$(git branch --show-current 2>/dev/null || echo "(detached)")
+START_TIME=$(date +%s)
+PATTERN=""
+CMD=""
+TIMEOUT=600
+
+# 検出ロジック (priority 1-10)
+if [[ -x tools/pre-commit ]]; then
+  PATTERN="tools/pre-commit (priority 1)"
+  CMD="./tools/pre-commit"
+  TIMEOUT=600
+elif [[ -f .pre-commit-config.yaml ]] && command -v pre-commit > /dev/null 2>&1; then
+  PATTERN=".pre-commit-config.yaml (priority 2)"
+  CMD="pre-commit run --all-files"
+  TIMEOUT=600
+elif [[ -f package.json ]] && command -v jq > /dev/null 2>&1 && jq -e '.scripts.validate' package.json > /dev/null 2>&1; then
+  PATTERN="package.json scripts.validate (priority 3)"
+  CMD="npm install --silent && npm run validate"
+  TIMEOUT=900
+elif [[ -f package.json ]] && command -v jq > /dev/null 2>&1 && jq -e '.scripts.test' package.json > /dev/null 2>&1; then
+  PATTERN="package.json scripts.test (priority 4)"
+  CMD="npm install --silent && npm test"
+  TIMEOUT=600
+elif [[ -f pyproject.toml ]] && [[ -f uv.lock ]]; then
+  PATTERN="pyproject.toml + uv.lock (priority 5)"
+  CMD="uv sync && uv run pytest"
+  TIMEOUT=900
+elif [[ -f pyproject.toml ]] && [[ -f poetry.lock ]]; then
+  PATTERN="pyproject.toml + poetry.lock (priority 6)"
+  CMD="poetry install && poetry run pytest"
+  TIMEOUT=900
+elif [[ -f Cargo.toml ]]; then
+  PATTERN="Cargo.toml (priority 7)"
+  CMD="cargo check && cargo test"
+  TIMEOUT=1200
+elif [[ -f go.mod ]]; then
+  PATTERN="go.mod (priority 8)"
+  CMD="go mod download && go test ./..."
+  TIMEOUT=600
+elif [[ -f Makefile ]] && grep -qE '^(test|check):' Makefile 2>/dev/null; then
+  PATTERN="Makefile test target (priority 9)"
+  CMD="make test"
+  TIMEOUT=600
+elif ls tests/*.bats > /dev/null 2>&1; then
+  PATTERN="tests/*.bats (priority 10)"
+  CMD="bats tests/"
+  TIMEOUT=600
+else
+  echo "## Worktree Healthcheck Result"
+  echo ""
+  echo "- **worktree path**: $WORKTREE_PATH"
+  echo "- **branch**: $BRANCH"
+  echo "- **result**: ⚠️ SKIP"
+  echo "- **reason**: 検出可能なテストフレームワークが見つかりません"
+  echo "- **suggestion**: README.md / CONTRIBUTING.md の \"Test\" セクション、または .github/workflows/*.yml の test job を参照してください"
+  exit 0
+fi
+
+# 実行
+OUTPUT_FILE=$(mktemp)
+trap 'rm -f "$OUTPUT_FILE"' EXIT
+
+EXIT_CODE=0
+timeout "$TIMEOUT" bash -c "$CMD" > "$OUTPUT_FILE" 2>&1 || EXIT_CODE=$?
+
+DURATION=$(($(date +%s) - START_TIME))
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+  RESULT="✅ PASS"
+elif [[ $EXIT_CODE -eq 124 ]]; then
+  RESULT="❌ FAIL (timeout)"
+else
+  RESULT="❌ FAIL"
+fi
+
+echo "## Worktree Healthcheck Result"
+echo ""
+echo "- **worktree path**: $WORKTREE_PATH"
+echo "- **branch**: $BRANCH"
+echo "- **detected pattern**: $PATTERN"
+echo "- **executed command**: \`$CMD\`"
+echo "- **duration**: ${DURATION}s"
+echo "- **result**: $RESULT"
+
+if [[ "$RESULT" == *"FAIL"* ]]; then
+  echo ""
+  echo "### Output (last 20 lines)"
+  echo '```'
+  tail -20 "$OUTPUT_FILE"
+  echo '```'
+  echo ""
+  echo "### Diagnostic"
+  if grep -qiE "node_modules|Cannot find module|biome: not found|eslint: not found|vitest: not found|package-lock\.json missing|uv\.lock not found" "$OUTPUT_FILE"; then
+    echo "**環境起因**の可能性が高い: 依存パッケージが未インストール。"
+    echo "npm install / uv sync / cargo build 等の依存解決コマンドを再実行してください。"
+    echo ".env / .env.test などの環境変数ファイルが配置されているかも確認してください。"
+  elif grep -qiE "permission denied|command not found|exec format error" "$OUTPUT_FILE"; then
+    echo "**ツール未インストール**の可能性: 必要なツール（pre-commit/uv/poetry/cargo/go/bats）を導入してください。"
+    echo "tools/pre-commit の場合は \`chmod +x tools/pre-commit\` で実行権限を確認してください。"
+  elif grep -qiE "TS[0-9]{4}|assertion (fail|error)|AssertionError" "$OUTPUT_FILE"; then
+    echo "**ベース起因**の可能性: main ブランチで同じ healthcheck を実行して比較してください。"
+    echo "main で PASS → 自 branch の実装問題。main でも FAIL → ベース起因（自 branch の問題ではない）。"
+  elif [[ $EXIT_CODE -eq 124 ]]; then
+    echo "**タイムアウト**: ${TIMEOUT}s 以内に完了しませんでした。"
+    echo "大規模テストスイートの可能性があります。家老に timeout 延長を依頼してください。"
+  else
+    echo "原因特定には Output セクションの精査が必要です。"
+    echo "家老に出力内容を共有して判断を仰いでください。"
+  fi
+fi
+
+exit 0

--- a/skills/worktree-healthcheck/scripts/healthcheck.sh
+++ b/skills/worktree-healthcheck/scripts/healthcheck.sh
@@ -40,7 +40,7 @@ pre_flight_env_symlink() {
     fi
 
     if [[ -e "$dst" ]] || [[ -L "$dst" ]]; then
-      ((skip_count++))
+      skip_count=$((skip_count + 1))
       echo "[env-symlink] already_exists: $f"
       continue
     fi
@@ -55,7 +55,7 @@ pre_flight_env_symlink() {
     fi
 
     if ln -sf "$src" "$dst" 2>/dev/null; then
-      ((symlink_count++))
+      symlink_count=$((symlink_count + 1))
       echo "[env-symlink] created: $f → $src"
     else
       echo "[env-symlink] WARN: symlink failed for $f"


### PR DESCRIPTION
## 概要

worktree作成直後に既存の検証フロー（pre-commit/test/build等）を1回流し、「環境起因 Fail」と「仕様起因 Fail」を早期切り分けする診断スキルを新設。

Closes #101

## 実装内容

### `skills/worktree-healthcheck/SKILL.md`

10セクション構成（Overview / When to Use / **Pre-flight: .env Symlink** / Detection Patterns / Decision Rule / Output Format / Failure Diagnostic / Examples / Guidelines / Implementation Note）

**cmd_210a追加**: worktree に `.env/local` 等がない場合、main worktree から symlink を作成する Pre-flight 処理を追加（Test Rule 5 充足）。

### `skills/worktree-healthcheck/scripts/healthcheck.sh`

**cmd_210b追加**: `pre_flight_env_symlink()` 関数を実装。`set -euo pipefail` 環境での `((count++))` バグ（count=0 時に exit status 1）を修正し、`$((count + 1))` 形式に統一。

10種のプロジェクト形式を priority 順に自動検出:

| priority | 検出ファイル | 実行コマンド |
|---|---|---|
| 1 | tools/pre-commit | ./tools/pre-commit |
| 2 | .pre-commit-config.yaml | pre-commit run --all-files |
| 3 | package.json (scripts.validate) | npm install && npm run validate |
| 4 | package.json (scripts.test) | npm install && npm test |
| 5 | pyproject.toml + uv.lock | uv sync && uv run pytest |
| 6 | pyproject.toml + poetry.lock | poetry install && poetry run pytest |
| 7 | Cargo.toml | cargo check && cargo test |
| 8 | go.mod | go mod download && go test ./... |
| 9 | Makefile (test target) | make test |
| 10 | tests/*.bats | bats tests/ |

失敗時に4カテゴリ（環境起因/ベース起因/ツール未インストール/タイムアウト）を grep で自動判定して診断メッセージを出力。

## 動作テスト（Pre-flight含む）

### Pre-flight .env Symlink テスト（issue-102-create-db worktree / cmd_210b修正版）

```
## Pre-flight: .env Symlink

[env-symlink] created: .env/local → /home/takuji.hiraoka/work/my-save2notion/.env/local
```

```
$ ls -la /home/takuji.hiraoka/work/my-save2notion-wt/issue-102-create-db/.env/local
lrwxrwxrwx 1 takuji.hiraoka takujihiraoka 51 May  7 15:28 /home/takuji.hiraoka/work/my-save2notion-wt/issue-102-create-db/.env/local -> /home/takuji.hiraoka/work/my-save2notion/.env/local
```

### テスト1: multi-agent-shogun 本体（priority 1 期待）

```
## Worktree Healthcheck Result
- worktree path: /home/takuji.hiraoka/work/multi-agent-shogun
- branch: feat/skill-worktree-healthcheck
- detected pattern: tools/pre-commit (priority 1)
- executed command: `./tools/pre-commit`
- duration: 345s
- result: ✅ PASS
```

### テスト2: my-save2notion worktree（priority 1 期待）

```
## Worktree Healthcheck Result
- worktree path: /home/takuji.hiraoka/work/my-save2notion-wt/issue-102-create-db
- branch: feat/issue-102-create-db
- detected pattern: tools/pre-commit (priority 1)
- executed command: `./tools/pre-commit`
- duration: 17s
- result: ✅ PASS
```

### テスト3: 空ディレクトリ（SKIP 期待）

```
## Worktree Healthcheck Result
- worktree path: /tmp/empty-healthcheck-test
- branch: (detached)
- result: ⚠️ SKIP
- reason: 検出可能なテストフレームワークが見つかりません
- suggestion: README.md / CONTRIBUTING.md の "Test" セクション、または .github/workflows/*.yml の test job を参照してください
```

## 軍師QC依頼事項（チェックリスト）

- [ ] SKILL.md Section 3「Pre-flight: .env Symlink」内容確認
  - main worktree 特定ロジック（git worktree list | head -1）
  - .env/local, .env.local, .env.test の3パターン網羅
  - ln -sf（symlink方式、cp禁止）
  - 失敗時の振る舞い（skip/警告のみ）記載
- [ ] frontmatter description が Pre-flight に言及済み
- [ ] Detection Patterns 10件全てが healthcheck.sh で実装されている
- [ ] 動作テスト証跡（ls -la）が PR本文に記載
- [ ] .gitignore whitelist 追加済み

## 殿向け確認事項

- [ ] `/worktree-healthcheck` スキルを起動してみて、動作を確認
- [ ] `bash skills/worktree-healthcheck/scripts/healthcheck.sh` が意図通り動作するか確認
- [ ] Pre-flight の .env symlink 機能が worktree で動作するか確認